### PR TITLE
Post-publish fixes: grader error surfacing, configurable skills dir, usage skill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ GEMINI_API_KEY=AIza...
 # GitHub Copilot CLI — must be a fine-grained PAT with "Copilot Requests" permission.
 COPILOT_GITHUB_TOKEN=ghp_...
 
+# --- Optional: where skills-under-test live (default ./.claude/skills) ---
+# Point at a non-.claude dir (e.g. ./skills) so your interactive coding agent
+# doesn't auto-load skills you're only testing. Also settable per-command via
+# --skills-dir. cultivar copies only the named skill into each isolated run.
+# CULTIVAR_SKILLS_DIR=skills
+
 # --- Optional: Modal workspace selection for --remote ---
 # If you belong to multiple Modal workspaces (e.g. personal + team), pin the
 # one cultivar --remote should use. Otherwise Modal picks whatever profile

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ cultivar init my-skill
 
 This writes `./tasks/my-skill.yaml` and `./.claude/skills/my-skill/SKILL.md`.
 
+> **Tip:** to test skills *without* your interactive coding agent auto-loading them, keep them outside `.claude/` — e.g. set `CULTIVAR_SKILLS_DIR=skills` (or pass `--skills-dir skills`) and `init` scaffolds into `./skills/my-skill/`. See [where skills live](docs/concepts.md#where-skills-live-and-testing-in-isolation).
+
 **3. Edit the skill** (`.claude/skills/my-skill/SKILL.md`)
 
 The skill file is what the agent sees when you invoke `/my-skill`. Write it like a concise brief: what the skill does, when to use it, and the key commands or patterns it should follow. Keep it tight — a few focused sections outperform a wall of text. If you're not sure where to start, drop your existing docs or a rough draft into Claude and ask it to write a SKILL.md for you.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Use traces to iteratively refine skills and optimize them against tasks.
 
 Benchmark against skills, docs, and baselines. And, even run in parallel simulatenously for faster execution.
 
-Want to use cultivar with an agent? Point it at this repo, or ask it to call --help to learn the tool!
+**Want your coding agent to drive cultivar?** Install the bundled skill:
+
+```bash
+npx skills add https://github.com/pinecone-io/cultivar --skill cultivar
+```
+
+It lands in `.claude/skills/cultivar/` (project scope) so your agent can invoke `/cultivar`. Keep it project-scoped — avoid the global `-g` install, which would sit in-context during local eval runs and skew the `without-skill` baseline (`--remote` is isolated regardless). The skill is never auto-tested: `cultivar run` only ever loads the single skill you pass to `-s`.
 
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Use traces to iteratively refine skills and optimize them against tasks.
 
 Benchmark against skills, docs, and baselines. And, even run in parallel simulatenously for faster execution.
 
-**Want your coding agent to drive cultivar?** Install the bundled skill:
+**Two ways to run it:** the `cultivar` CLI directly, or install the bundled skill and let your coding agent drive it:
 
 ```bash
 npx skills add https://github.com/pinecone-io/cultivar --skill cultivar
 ```
 
-It lands in `.claude/skills/cultivar/` (project scope) so your agent can invoke `/cultivar`. Keep it project-scoped — avoid the global `-g` install, which would sit in-context during local eval runs and skew the `without-skill` baseline (`--remote` is isolated regardless). The skill is never auto-tested: `cultivar run` only ever loads the single skill you pass to `-s`.
+Same engine either way — but when an agent drives it you won't watch the live run / `--remote` sandbox dashboard as directly as in your own terminal. Keep the skill project-scoped (not `-g`); it's never auto-tested.
 
 
 ## Prerequisites

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -48,6 +48,30 @@ If `with-skill` beats `with-docs` on pass rate or cost, your distillation is rea
 
 > **Caveat** The without-skill variant isn't a strictly identical baseline across all runners. On **Claude**, without-skill is a clean baseline — same flags, just no skill mounted and no `Use the /<skill>` in the prompt; we used to pass `--bare` but removed it after it silently filtered `Write` from the tool set and broke code-gen. On **Copilot**, without-skill still passes `--no-custom-instructions` and `--excluded-tools skill`, so the delta there reflects skill + AGENTS.md loading. Pass-rate comparisons are honest everywhere; token/cost comparisons are directionally useful but not strictly like-for-like across runners.
 
+## Where skills live (and testing in isolation)
+
+cultivar tests **one** skill per run — the one you name with `-s/--skill`. It resolves that skill from a single directory and never sweeps the whole folder, so a repo full of unrelated skills is safe: only the named one is ever loaded.
+
+**Resolution order** for the skills root (the dir that holds `<skill-name>/SKILL.md`):
+
+1. `--skills-dir <path>` flag
+2. `CULTIVAR_SKILLS_DIR` env var
+3. `./.claude/skills` (default)
+
+**Testing in isolation.** If your skills-under-test live in `.claude/skills/`, your *interactive* coding agent (Claude Code, etc.) running in that repo will also auto-load them — so a skill you're only evaluating becomes active in your everyday agent. To avoid that, keep them under a non-`.claude` directory (e.g. `./skills`) and point cultivar at it:
+
+```bash
+export CULTIVAR_SKILLS_DIR=skills      # or pass --skills-dir skills per command
+cultivar init my-skill                 # scaffolds ./skills/my-skill/SKILL.md
+cultivar run -s my-skill -r claude --grade
+```
+
+That's exactly the shape of a skills monorepo like [pinecone-io/skills](https://github.com/pinecone-io/skills) (`skills/<name>/SKILL.md`): set `CULTIVAR_SKILLS_DIR=skills` once (e.g. in a CI job) and every command resolves correctly.
+
+**What the eval agent sees.** Wherever the *source* lives, cultivar copies only the named skill into each run's isolated workspace (a tempdir locally, a fresh sandbox remotely) at `.claude/skills/<name>/`, so the agent-under-eval discovers it there. Your other skills are never copied into a run.
+
+> **Local caveat.** Locally the run happens in a `/tmp` tempdir, so your repo's other skills aren't reachable — but a coding-CLI agent may still load **machine-global** skills from `~/.claude/skills/` (user-level, not your repo), which can subtly contaminate the `without-skill` control. `--remote` is fully isolated; prefer it for rigorous comparisons.
+
 ## What "better" means
 
 Three signals, all in `grades.json` and the report:

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -376,6 +376,38 @@ def build_grader_prompt(
     return "\n".join(parts)
 
 
+# Markers that indicate the agent RUN itself failed (auth/API/quota/etc.) rather
+# than a clean run that simply wrote nothing — used to give an accurate cause when
+# a code-gen workdir is empty (see grade_one's autofail).
+_RUN_ERROR_MARKERS = (
+    "invalid api key",
+    "fix external api key",
+    "authentication_error",
+    "permission denied",
+    "rate limit",
+    "overloaded_error",
+    "insufficient_quota",
+    "credit balance is too low",
+    "could not resolve",
+)
+
+
+def _detect_run_error(conversation: dict, conv_str: str) -> str:
+    """Short description of an agent-run error if the trace shows one, else ""."""
+    if conversation.get("is_error") or conversation.get("api_error_status"):
+        result = (conversation.get("result") or "").strip()
+        if result:
+            return result[:200]
+    low = conv_str.lower()
+    for marker in _RUN_ERROR_MARKERS:
+        if marker in low:
+            for line in conv_str.splitlines():
+                if marker in line.lower():
+                    return line.strip().lstrip("*# ").strip()[:200]
+            return marker
+    return ""
+
+
 def grade_one(
     client: Anthropic,
     model: str,
@@ -409,6 +441,20 @@ def grade_one(
     # otherwise pattern-match against Skill Reference / Reference Material
     # and report fabricated code as evidence.
     if task.get("category") == "code-gen" and not workdir_content.strip():
+        run_error = _detect_run_error(conversation, conv_str)
+        if run_error:
+            return {
+                "pass": False,
+                "proposed_command": "",
+                "evidence": "",
+                "reasoning": f"Code-gen task produced no files: the agent run errored ({run_error}). Not sent to grader.",
+                "suggestions": [
+                    {
+                        "cause": f"The agent run failed before writing any files: {run_error}",
+                        "fix": "Resolve the agent error shown in the conversation (e.g. fix the API key / auth in your Modal secret or local environment), then re-run. See <run>/<runner>/<base>.md and .stderr.log.",
+                    }
+                ],
+            }
         return {
             "pass": False,
             "proposed_command": "",

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -11,7 +11,7 @@ import yaml
 from anthropic import Anthropic
 from anthropic.types import TextBlock
 
-from evals.framework.reporting import console, print_report, resolve_results_dir
+from evals.framework.reporting import console, print_report, resolve_results_dir, resolve_skills_base
 
 
 def _require_anthropic_key() -> None:
@@ -34,7 +34,6 @@ def _require_anthropic_key() -> None:
 
 
 EXAMPLES_DIR = Path.cwd() / "examples"
-DEFAULT_SKILLS_DIR = Path.cwd() / ".claude" / "skills"
 
 DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
@@ -584,7 +583,9 @@ def main(
     report: bool = typer.Option(
         True, help="Print the report after grading. Use --no-report to only write grades.json."
     ),
-    skills_dir: str = typer.Option("", "--skills-dir", help="Override path to skills root. Default: ./.claude/skills."),
+    skills_dir: str = typer.Option(
+        "", "--skills-dir", help="Skills root dir. Overrides CULTIVAR_SKILLS_DIR env; default ./.claude/skills."
+    ),
 ):
     """Grade an existing results dir with the LLM grader; writes grades.json and prints a report.
 
@@ -628,7 +629,7 @@ def main(
         console.print(f"[dim]{n_examples} calibration examples available[/dim]")
 
     # Load SKILL.md for grader context
-    base_dir = Path(skills_dir) if skills_dir else DEFAULT_SKILLS_DIR
+    base_dir = resolve_skills_base(skills_dir)
     skill_md = base_dir / skill / "SKILL.md"
     skill_content = ""
     if skill_md.exists():

--- a/evals/framework/reporting.py
+++ b/evals/framework/reporting.py
@@ -1,5 +1,6 @@
 """Shared reporting utilities for the eval framework."""
 
+import os
 from collections import defaultdict
 from pathlib import Path
 from typing import TypedDict
@@ -11,6 +12,21 @@ from rich.table import Table
 from rich.text import Text
 
 console = Console()
+
+
+def resolve_skills_base(skills_dir_flag: str = "") -> Path:
+    """Resolve the skills root directory (the dir that contains <skill-name>/SKILL.md).
+
+    Precedence: ``--skills-dir`` flag > ``CULTIVAR_SKILLS_DIR`` env var > ``./.claude/skills``.
+    Relative values are anchored to the current working directory. Keeping skills under a
+    non-``.claude`` dir (e.g. ``./skills``) lets you eval them without your interactive coding
+    agent auto-loading them; cultivar still copies only the named skill into each isolated run.
+    """
+    raw = skills_dir_flag or os.environ.get("CULTIVAR_SKILLS_DIR") or ""
+    if raw:
+        p = Path(raw)
+        return p if p.is_absolute() else Path.cwd() / p
+    return Path.cwd() / ".claude" / "skills"
 
 
 class _VariantStats(TypedDict):

--- a/evals/init.py
+++ b/evals/init.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from evals.framework.reporting import console
+from evals.framework.reporting import console, resolve_skills_base
 
 app = typer.Typer(pretty_exceptions_enable=False)
 
@@ -92,20 +92,25 @@ def main(
     skill_md: bool = typer.Option(
         True,
         "--skill-md/--no-skill-md",
-        help="Also create .claude/skills/<skill>/SKILL.md as a placeholder. Default: yes.",
+        help="Also create <skills-dir>/<skill>/SKILL.md as a placeholder. Default: yes.",
+    ),
+    skills_dir: str = typer.Option(
+        "", "--skills-dir", help="Skills root dir. Overrides CULTIVAR_SKILLS_DIR env; default ./.claude/skills."
     ),
 ):
-    """Scaffold tasks/<skill>.yaml (+ placeholder .claude/skills/<skill>/SKILL.md) for a new skill.
+    """Scaffold tasks/<skill>.yaml (+ placeholder <skills-dir>/<skill>/SKILL.md) for a new skill.
 
     Writes ./tasks/<skill>.yaml with three template tasks (CLI-style, code-gen,
-    and one with context_refs to activate the with-docs runner variant), and
-    ./.claude/skills/<skill>/SKILL.md with a stub. Both paths are cwd-relative —
-    run this from the repo where you want the skill to live.
+    and one with context_refs to activate the with-docs runner variant), and a
+    SKILL.md stub under the resolved skills dir. The skills dir is ./.claude/skills
+    by default; override with --skills-dir or the CULTIVAR_SKILLS_DIR env var (e.g.
+    keep skills under ./skills so your interactive agent doesn't auto-load them).
 
     Examples:
-      cultivar init my-skill                # scaffold both files
-      cultivar init my-skill --no-skill-md  # only the task YAML; reuse an existing skill
-      cultivar init my-skill --force        # overwrite an existing tasks file
+      cultivar init my-skill                  # scaffold both files
+      cultivar init my-skill --skills-dir skills  # scaffold SKILL.md under ./skills/
+      cultivar init my-skill --no-skill-md    # only the task YAML; reuse an existing skill
+      cultivar init my-skill --force          # overwrite an existing tasks file
 
     See docs/task-yaml.md for the full task schema and docs/concepts.md for the
     with-skill / without-skill / with-docs variant breakdown.
@@ -113,27 +118,33 @@ def main(
     cwd = Path.cwd()
     tasks_dir = cwd / "tasks"
     task_file = tasks_dir / f"{skill}.yaml"
-    skill_md_path = cwd / ".claude" / "skills" / skill / "SKILL.md"
+    skill_md_path = resolve_skills_base(skills_dir) / skill / "SKILL.md"
+
+    def _disp(p: Path) -> str:
+        try:
+            return str(p.relative_to(cwd))
+        except ValueError:
+            return str(p)
 
     created = []
     skipped = []
 
     # tasks/<skill>.yaml
     if task_file.exists() and not force:
-        skipped.append(f"{task_file.relative_to(cwd)} (already exists; use --force to overwrite)")
+        skipped.append(f"{_disp(task_file)} (already exists; use --force to overwrite)")
     else:
         tasks_dir.mkdir(parents=True, exist_ok=True)
         task_file.write_text(TASK_TEMPLATE.format(skill=skill))
-        created.append(str(task_file.relative_to(cwd)))
+        created.append(_disp(task_file))
 
-    # .claude/skills/<skill>/SKILL.md — only if --skill-md and not already there
+    # <skills-dir>/<skill>/SKILL.md — only if --skill-md and not already there
     if skill_md:
         if skill_md_path.exists() and not force:
-            skipped.append(f"{skill_md_path.relative_to(cwd)} (already exists)")
+            skipped.append(f"{_disp(skill_md_path)} (already exists)")
         else:
             skill_md_path.parent.mkdir(parents=True, exist_ok=True)
             skill_md_path.write_text(SKILL_TEMPLATE.format(skill=skill))
-            created.append(str(skill_md_path.relative_to(cwd)))
+            created.append(_disp(skill_md_path))
 
     for path in created:
         console.print(f"[green]created[/green]  {path}")
@@ -141,8 +152,9 @@ def main(
         console.print(f"[yellow]skipped[/yellow]  {note}")
 
     if created:
+        sd = f" --skills-dir {skills_dir}" if skills_dir else ""
         console.print(
-            f"\nNext: edit the tasks file and run [bold]cultivar run --skill {skill} --runner claude[/bold]"
+            f"\nNext: edit the tasks file and run [bold]cultivar run --skill {skill} --runner claude{sd}[/bold]"
         )
 
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -13,13 +13,13 @@ from pathlib import Path
 import typer
 import yaml
 
+from evals.framework.reporting import resolve_skills_base
 from evals.runners.claude import ClaudeRunner
 from evals.runners.copilot import CopilotRunner
 from evals.runners.gemini import GeminiRunner
 
 TASKS_DIR = Path.cwd() / "tasks"
 RESULTS_DIR = Path.cwd() / "results"
-DEFAULT_SKILLS_DIR = Path.cwd() / ".claude" / "skills"
 
 RUNNER_CLASSES = {
     "claude": ClaudeRunner,
@@ -410,7 +410,9 @@ def main(
         help="Wall-clock budget (seconds) for each agent CLI invocation. Remote sandboxes get this plus a 60s buffer for setup/verify/teardown.",
     ),
     repeat: int = typer.Option(1, "--repeat", "-n", help="Run each (task, variant) N times for reliability stats."),
-    skills_dir: str = typer.Option("", "--skills-dir", help="Override path to skills root. Default: ./.claude/skills."),
+    skills_dir: str = typer.Option(
+        "", "--skills-dir", help="Skills root dir. Overrides CULTIVAR_SKILLS_DIR env; default ./.claude/skills."
+    ),
     title: str = typer.Option("", "--title", help="Name this run; appears in the results dir name."),
     notes: str = typer.Option("", "--notes", help="Free-form notes saved to <run>/notes.md and shown in the report."),
     remote: bool = typer.Option(
@@ -460,7 +462,7 @@ def main(
         raise typer.Exit(1)
 
     # Resolve skill directory for with-skill variant
-    base_dir = Path(skills_dir) if skills_dir else DEFAULT_SKILLS_DIR
+    base_dir = resolve_skills_base(skills_dir)
     skill_dir = base_dir / skill
     if not (skill_dir / "SKILL.md").exists():
         typer.echo(f"Error: Skill '{skill}' not found at {skill_dir}")

--- a/skills/cultivar/SKILL.md
+++ b/skills/cultivar/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: cultivar
+description: Drive the cultivar CLI to test whether an agent skill improves behavior — scaffold tasks, run with/without the skill across Claude/Copilot/Gemini (locally or on Modal), grade against a rubric, and read the results.
+---
+
+# cultivar
+
+cultivar is a CLI that measures whether an agent **skill** actually improves an agent's
+behavior. For each task it runs the agent **with the skill** and **without** it (and
+optionally **with the source docs**), then an LLM grader scores each run against a
+natural-language rubric. Use this skill when the user wants to create, run, or interpret
+cultivar evals.
+
+## The loop
+
+1. `cultivar init <skill>` — scaffold `tasks/<skill>.yaml` + a `SKILL.md` stub.
+2. Edit the task file (intent + PASS/FAIL criteria) and the skill.
+3. `cultivar run -s <skill> -r <runner> --grade` — run all variants and grade.
+4. `cultivar report` / `cultivar show latest -t <task>` — read the outcome.
+5. Iterate on the skill; re-run; compare.
+
+Always confirm the install first with `cultivar hello` (or `cultivar hello --no-grade`
+when no `ANTHROPIC_API_KEY` is available) — it runs a packaged smoke task end-to-end.
+
+## Commands
+
+- `cultivar init <skill> [--skills-dir DIR]` — scaffold task YAML + SKILL.md stub.
+- `cultivar run -s <skill> -r <claude|copilot|gemini>` — run. Key flags:
+  - `-t <task>` one task · `-v <with-skill|without-skill|with-docs>` one variant
+  - `--remote` run in isolated Modal sandboxes · `-n N` repeat · `-p N` parallelism
+  - `--grade` grade after running · `--title NAME` label the run · `--dry-run` print the
+    prompt + command without calling anything · `--timeout S` per-call budget (default 90)
+- `cultivar grade <run|latest> -s <skill> [--report]` — (re)grade an existing run.
+- `cultivar report [run]` — summary table across runners/variants.
+- `cultivar show <run|latest> -t <task> [--grader|--conversation-only|--workdir]` — inspect one run.
+
+`--dry-run` is the safe way to preview exactly what will be sent before spending tokens.
+
+## Variants (the controls)
+
+- **with-skill** — skill loaded; prompt prefixed `Use the /<skill>`.
+- **without-skill** — no skill; identical otherwise. The baseline.
+- **with-docs** — no skill, but the task's `ground_truth.context_refs` files are prepended.
+  Only runs for tasks that declare `context_refs`.
+
+Read two deltas: with-skill vs without-skill ("does the skill do anything?") and
+with-skill vs with-docs ("is the distilled skill better than dumping the raw docs?").
+
+## Tasks
+
+`tasks/<skill>.yaml` holds one or more tasks. Each task:
+
+```yaml
+tasks:
+  - id: a-short-id
+    intent: "what you'd ask the agent to do"
+    category: cli            # or: code-gen
+    # setup / teardown / verify: optional shell hooks
+    # env: ["SOME_KEY"]      # required env vars, checked upfront
+    ground_truth:
+      criteria: |
+        PASS requires <2-3 concrete, checkable things>.
+        FAIL if <a common failure mode>.
+      # context_refs: [docs/ref.md]   # activates the with-docs variant
+```
+
+Guidance:
+- For **code-gen** tasks, the intent must say "write a file … in the current directory."
+  Anything the agent writes to its cwd is captured and shown to the grader. A code-gen
+  task that produces no file auto-fails.
+- Write criteria as crisp PASS conditions + at least one concrete FAIL mode — vague
+  criteria produce vague grades.
+
+## Where skills live
+
+cultivar tests exactly **one** skill per run (the `-s` one). It resolves the skills root
+as: `--skills-dir` flag → `CULTIVAR_SKILLS_DIR` env → `./.claude/skills`. Keep
+skills-under-test outside `.claude/` (e.g. `./skills`, via `CULTIVAR_SKILLS_DIR=skills`)
+if you don't want your interactive coding agent to auto-load them.
+
+## Local vs remote
+
+- **Local** (default) — uses the runner CLI installed on your machine + its auth.
+- **`--remote`** — each (task, variant, repeat) runs in its own Modal sandbox: clean
+  isolation, parallelism, reproducibility. Requires a Modal account (`modal token new`)
+  and a secret holding the agent's `ANTHROPIC_API_KEY` (default secret name
+  `eval-sandbox-secrets`; override with `CULTIVAR_MODAL_SECRET`). Prefer `--remote` for
+  rigorous comparisons. The grader always runs locally and needs `ANTHROPIC_API_KEY`.
+
+## Reading results
+
+`results/<timestamp>[__title]/` holds per-run `.json` (stats), `.md` (readable trace),
+`.jsonl` (raw events), and `.workdir/` (files the agent wrote). `grades.json` holds the
+verdicts. Use `cultivar report` for the table and `cultivar show … --grader` for the
+grader's reasoning + suggestions on a failure.
+
+## Gotchas
+
+- Grading needs `ANTHROPIC_API_KEY` (loaded from a `.env` in the cwd). `hello --no-grade`
+  and `run --dry-run` need no key.
+- `tasks/`, `examples/`, and `results/` are cwd-relative and user-owned.
+- One run is a sample, not a signal — use `-n 3` (or more) for anything you'll act on.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -986,6 +986,26 @@ class TestCodeGenEmptyWorkdirAutofail:
         assert result["suggestions"]
         assert "Write" in result["suggestions"][0]["fix"]
 
+    def test_code_gen_empty_workdir_surfaces_run_error(self):
+        """When the workdir is empty because the agent RUN errored (e.g. a bad
+        API key), the autofail surfaces that error rather than the generic
+        'check Write/Edit' suggestion."""
+        task = {"id": "t", "category": "code-gen", "ground_truth": {"criteria": "x"}}
+        conv = {"conversation_md": "**User:** write greeting.txt\n\n**Assistant:** Invalid API key · Fix external API key\n"}
+        result = self.grade(
+            client=None,  # ty: ignore[invalid-argument-type] -- intentional: autofail returns before using client
+            model="x",
+            task=task,
+            conversation=conv,
+            examples_block="",
+            skill_content="",
+            workdir_content="",
+        )
+        assert result["pass"] is False
+        blob = (result["reasoning"] + result["suggestions"][0]["cause"] + result["suggestions"][0]["fix"]).lower()
+        assert "invalid api key" in blob
+        assert "write/edit" not in result["suggestions"][0]["fix"].lower()
+
     def test_code_gen_with_workdir_proceeds_to_grader(self, monkeypatch):
         """When workdir has content, we don't short-circuit — verified by the
         function trying to call client.messages.create and raising AttributeError

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1182,3 +1182,34 @@ class TestOrchestratorCallSurface:
             "without-skill saw the skill mounted in its cwd. The baseline variant must run "
             "with no skill discoverable; otherwise the with/without delta isn't honest."
         )
+
+
+class TestResolveSkillsBase:
+    """resolve_skills_base() precedence: --skills-dir flag > CULTIVAR_SKILLS_DIR env > ./.claude/skills."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from evals.framework.reporting import resolve_skills_base
+
+        self.resolve = resolve_skills_base
+
+    def test_default_is_dot_claude_skills(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CULTIVAR_SKILLS_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve("") == tmp_path / ".claude" / "skills"
+
+    def test_env_var_overrides_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CULTIVAR_SKILLS_DIR", "skills")
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve("") == tmp_path / "skills"
+
+    def test_flag_overrides_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CULTIVAR_SKILLS_DIR", "skills")
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve("from-flag") == tmp_path / "from-flag"
+
+    def test_absolute_value_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CULTIVAR_SKILLS_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        abs_dir = tmp_path / "elsewhere" / "skills"
+        assert self.resolve(str(abs_dir)) == abs_dir


### PR DESCRIPTION
Post-0.1.0 fixes from verifying the three core workflows (hello / local / remote) end-to-end and addressing skill-scoping gaps. All three workflows were run live (local + Modal `--remote`) and pass; the grader bug below was found during that verification.

## Changes

**`fix(grader)`: surface agent run errors on empty code-gen workdir**
When a code-gen run produced no files because the *agent* errored (e.g. `Invalid API key` from a bad sandbox secret), the empty-workdir autofail printed the generic "check Write/Edit tools" suggestion — sending debugging the wrong way. It now detects auth/API/quota error markers in the trace and surfaces the real error as the cause. New `_detect_run_error()` + test.

**`feat(skills)`: configurable skills dir via `CULTIVAR_SKILLS_DIR`**
Skills root now resolves as `--skills-dir` flag → `CULTIVAR_SKILLS_DIR` env → `./.claude/skills`, via a shared `resolve_skills_base()` used by `run`, `grade`, and `init` (which now scaffolds into the resolved dir too). This lets you keep skills-under-test outside `.claude/` (e.g. a `skills/<name>/` monorepo like `pinecone-io/skills`) so your interactive coding agent doesn't auto-load them — set `CULTIVAR_SKILLS_DIR=skills` once in CI. Docs: a "Where skills live (and testing in isolation)" section in `docs/concepts.md`, a README tip, and `.env.example`. Tests cover resolution precedence.

**`feat(skill)`: ship the `cultivar` usage skill**
`skills/cultivar/SKILL.md` teaches a coding agent to drive cultivar (the init → run/`--grade` → report/show loop, variants, skills dir, local vs `--remote`, gotchas). Installable via the skills.sh CLI:

```bash
npx skills add https://github.com/pinecone-io/cultivar --skill cultivar
```

Placed at the flat `skills/<name>/SKILL.md` layout the CLI discovers; installs to project-scope `.claude/skills/` by default. It's never auto-tested — `cultivar run` loads only the single `-s` skill and requires a matching `tasks/<skill>.yaml`, which the helper ships neither.

## Verification
- 92 tests pass; `ruff` + `ty` clean.
- `cultivar hello` (graded + `--no-grade`), a local `init`→`run --grade`, and a Modal `--remote --grade` run all PASS.
- `init --skills-dir` + `CULTIVAR_SKILLS_DIR` resolution verified end-to-end.
- Note: the `npx skills add` install can only be verified once this is on `main` (it pulls the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)