### PR TITLE
ci: add least-privilege permissions and pin setup-uv to SHA (CodeQL)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,22 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Safe default; the publish job overrides with its required scopes below.
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write # required for OIDC token exchange with PyPI
     steps:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Build distributions
         run: uv build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default: test job only reads the checkout.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -14,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
Resolves all 3 open CodeQL alerts on this repo.

## Changes
| File | Fix |
|---|---|
| **test.yml** | Add `permissions: contents: read` (alert #1). Pin `astral-sh/setup-uv@v5` → full commit SHA (alert #3). |
| **publish.yml** | Add workflow-level `permissions: contents: read` default. Pin `astral-sh/setup-uv@v5` → full commit SHA (alert #2). Explicitly add `contents: read` to the job-level override block (job-level permissions *replace* the workflow default, so it must be included there too alongside `id-token: write`). |

SHA used: `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86` (= `astral-sh/setup-uv@v5`, verified via the GitHub API).

## Verification
- YAML parses cleanly (`ruby -ryaml`).
- No behavior change — OIDC publish still works (job-level `id-token: write` preserved).

Part of PIN-16 (security tail), child of PIN-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)