### PR TITLE
ci: pin setup-uv to SHA + add test workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Build distributions
         run: uv build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege default: the test job only reads the repo to run pytest.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -14,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## What
- Add top-level `permissions: contents: read` to `test.yml`.
- Pin `astral-sh/setup-uv` from the mutable `@v5` tag to the commit SHA it currently resolves to (`d4b2f3b`, v5.4.2) in both `test.yml` and `publish.yml`, with a version comment.

## Why
CodeQL flagged 3 alerts: 1x `actions/missing-workflow-permissions` (test.yml) and 2x `actions/unpinned-tag` (setup-uv in both files). The test job is read-only. Pinning to a full commit SHA closes the tag-repoint supply-chain vector while the `# v5.4.2` comment keeps the version legible. No behavior change — SHA is what `@v5` resolves to today.

`publish.yml` already has a least-privilege job permissions block (`id-token: write` for PyPI Trusted Publishing), so only its tag is pinned.

## Verification
- YAML parses; `test.yml` has `permissions: {contents: read}`; both `uses:` lines pinned to SHA.

Resolves 3 code-scanning alerts. Refs PIN-24.