### PR TITLE
fix: exit nonzero on eval failure

### DIFF
--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -11,7 +11,13 @@ import yaml
 from anthropic import Anthropic
 from anthropic.types import TextBlock
 
-from evals.framework.reporting import console, print_report, resolve_results_dir, resolve_skills_base
+from evals.framework.reporting import (
+    console,
+    gate_verdict,
+    print_report,
+    resolve_results_dir,
+    resolve_skills_base,
+)
 
 
 def _require_anthropic_key() -> None:
@@ -586,6 +592,17 @@ def main(
     skills_dir: str = typer.Option(
         "", "--skills-dir", help="Skills root dir. Overrides CULTIVAR_SKILLS_DIR env; default ./.claude/skills."
     ),
+    fail_under: float | None = typer.Option(
+        None,
+        "--fail-under",
+        help=(
+            "Exit 1 if the with-skill pass rate is below this percentage (0-100). "
+            "Omit to always exit 0. Intended for CI gates."
+        ),
+    ),
+    gate_variant: str = typer.Option(
+        "with-skill", "--gate-variant", help="Variant that --fail-under measures. Default: with-skill."
+    ),
 ):
     """Grade an existing results dir with the LLM grader; writes grades.json and prints a report.
 
@@ -599,6 +616,7 @@ def main(
       cultivar grade results/2026-04-22T11-31-47__baseline   # grade a specific run
       cultivar grade latest --model claude-sonnet-4-6        # use a stronger grader
       cultivar grade latest --no-report                      # write grades.json, skip the report
+      cultivar grade latest --fail-under 80                  # exit 1 if with-skill pass rate < 80%
 
     See docs/grader.md for prompt structure and calibration tips.
     """
@@ -741,6 +759,15 @@ def main(
         if notes_file.exists():
             notes = notes_file.read_text()
         print_report(grades, notes)
+
+    # CI gate. Nothing above this line exits nonzero on a bad result, so without
+    # --fail-under a failing eval still reports success to the caller.
+    if fail_under is not None:
+        ok, summary = gate_verdict(grades, fail_under, gate_variant)
+        if not ok:
+            console.print(f"[red]Gate failed: {summary}[/red]")
+            raise typer.Exit(1)
+        console.print(f"[green]Gate passed: {summary}[/green]")
 
 
 if __name__ == "__main__":

--- a/evals/framework/report.py
+++ b/evals/framework/report.py
@@ -4,14 +4,83 @@ import json
 
 import typer
 
-from evals.framework.reporting import console, print_report, resolve_results_dir
+from evals.framework.reporting import console, gate_pass_rate, print_report, resolve_results_dir
 
 app = typer.Typer(pretty_exceptions_enable=False)
+
+VARIANT_ORDER = ["with-skill", "without-skill", "with-docs"]
+
+
+def _summarize(grades: list[dict]) -> dict:
+    """Machine-readable summary of a graded run.
+
+    Shape is deliberately flat and stable: CI writes this to a PR comment or keeps it
+    as a trend record, so fields should only ever be added, never renamed.
+    """
+    variants = {}
+    seen = [v for v in VARIANT_ORDER if any(g.get("variant") == v for g in grades)]
+    seen += sorted({g.get("variant", "") for g in grades} - set(VARIANT_ORDER) - {""})
+    for v in seen:
+        rate, passed, total = gate_pass_rate(grades, v)
+        variants[v] = {"pass_rate": round(rate, 1), "passed": passed, "total": total}
+
+    return {
+        "total_conversations": len(grades),
+        "variants": variants,
+        "cost_usd": round(sum(g.get("cost_usd") or 0 for g in grades), 4),
+        "duration_s": round(sum(g.get("duration_s") or 0 for g in grades), 1),
+        "failures": [
+            {
+                "task_id": g.get("task_id", ""),
+                "runner": g.get("runner", ""),
+                "variant": g.get("variant", ""),
+                "run_num": g.get("run_num", 1),
+                "evidence": g.get("evidence", ""),
+            }
+            for g in grades
+            if not g.get("pass")
+        ],
+    }
+
+
+def _render_md(grades: list[dict], run_name: str) -> str:
+    """GitHub-flavoured markdown, sized for a PR comment."""
+    s = _summarize(grades)
+    lines = [f"### Eval report — `{run_name}`", ""]
+    lines += ["| Variant | Pass rate | Passed | Total |", "|---|---:|---:|---:|"]
+    for v, st in s["variants"].items():
+        lines.append(f"| `{v}` | {st['pass_rate']:.1f}% | {st['passed']} | {st['total']} |")
+    lines += [
+        "",
+        f"{s['total_conversations']} conversation(s) · "
+        f"${s['cost_usd']:.4f} · {s['duration_s']:.1f}s",
+    ]
+
+    if s["failures"]:
+        lines += ["", f"<details><summary>{len(s['failures'])} failure(s)</summary>", ""]
+        for f in s["failures"]:
+            loc = f"`{f['task_id']}` — {f['runner']}/{f['variant']}"
+            if f["run_num"] != 1:
+                loc += f" (run {f['run_num']})"
+            evidence = " ".join((f["evidence"] or "").split())
+            if len(evidence) > 300:
+                evidence = evidence[:297] + "..."
+            lines.append(f"- {loc}{': ' + evidence if evidence else ''}")
+        lines += ["", "</details>"]
+    else:
+        lines += ["", "No failures."]
+
+    return "\n".join(lines) + "\n"
 
 
 @app.command()
 def main(
     results_dir: str = typer.Argument("latest", help="Results dir to print. Use 'latest' for the most recent."),
+    format: str = typer.Option(
+        "rich",
+        "--format",
+        help="Output format: rich (default, terminal panels), md (PR comment), or json (machine-readable).",
+    ),
 ):
     """Print a report from a graded results dir (no grading, no API calls).
 
@@ -20,10 +89,20 @@ def main(
     panels include grader-supplied remediation suggestions (cause → fix) when
     present. For a deeper view of one run, use `cultivar show`.
 
+    `--format md` and `--format json` write plain output to stdout with no Rich
+    markup, so they can be redirected into a PR comment or a trend record.
+
     Examples:
       cultivar report                                        # latest run
       cultivar report results/2026-04-22T11-31-47__baseline  # specific run
+      cultivar report --format md >> "$GITHUB_STEP_SUMMARY"  # CI job summary
+      cultivar report --format json | jq .variants           # machine-readable
     """
+    fmt = format.lower()
+    if fmt not in ("rich", "md", "json"):
+        console.print(f"[red]Unknown --format '{format}'. Use rich, md, or json.[/red]")
+        raise typer.Exit(2)
+
     results_path = resolve_results_dir(results_dir)
     grades_file = results_path / "grades.json"
     if not grades_file.exists():
@@ -32,6 +111,16 @@ def main(
 
     with open(grades_file) as f:
         grades = json.load(f)
+
+    # Machine-readable formats bypass Rich entirely — console applies markup and
+    # wraps to terminal width, both of which corrupt piped output.
+    if fmt == "json":
+        payload = {"run": results_path.name, **_summarize(grades)}
+        print(json.dumps(payload, indent=2))
+        return
+    if fmt == "md":
+        print(_render_md(grades, results_path.name), end="")
+        return
 
     console.print(f"\n[bold]EVAL REPORT:[/bold] {results_path.name}\n")
 

--- a/evals/framework/reporting.py
+++ b/evals/framework/reporting.py
@@ -49,10 +49,66 @@ def _new_variant_stats() -> _VariantStats:
     }
 
 
+def resolve_results_base() -> Path:
+    """Resolve the results root directory (the dir that holds one subdir per run).
+
+    Precedence: ``CULTIVAR_RESULTS_DIR`` env var > ``./results``. Relative values are
+    anchored to the current working directory. Mirrors :func:`resolve_skills_base`.
+
+    CI needs this: results are written per-run and are large, so a job can point them
+    at ``$RUNNER_TEMP`` instead of the checkout and upload only ``grades.json``.
+    """
+    raw = os.environ.get("CULTIVAR_RESULTS_DIR") or ""
+    if raw:
+        p = Path(raw)
+        return p if p.is_absolute() else Path.cwd() / p
+    return Path.cwd() / "results"
+
+
+def gate_pass_rate(grades: list[dict], variant: str = "with-skill") -> tuple[float, int, int]:
+    """Pass rate for one variant, as a percentage, plus (passed, total) counts.
+
+    Only ``variant`` is counted. The gate deliberately ignores ``without-skill``: it is
+    the baseline and is *expected* to fail, so including it would make any threshold
+    meaningless. Returns ``(0.0, 0, 0)`` when the variant produced no grades — callers
+    treat an empty result set as a failure rather than a vacuous pass.
+    """
+    rows = [g for g in grades if g.get("variant") == variant]
+    total = len(rows)
+    passed = sum(1 for g in rows if g.get("pass"))
+    rate = (passed / total * 100) if total else 0.0
+    return rate, passed, total
+
+
+def gate_verdict(
+    grades: list[dict], threshold: float, variant: str = "with-skill"
+) -> tuple[bool, str]:
+    """Decide whether a graded run clears the CI threshold.
+
+    Returns ``(ok, message)``. Kept separate from the CLI so the decision is pure and
+    testable — the caller does the printing and the exit.
+
+    An empty result set is a **failure**, not a vacuous pass: a run that produced no
+    ``variant`` grades at all usually means the runner or the task filter broke, and
+    that must not read as green.
+    """
+    rate, passed, total = gate_pass_rate(grades, variant)
+    if total == 0:
+        return False, f"no {variant} grades to measure"
+    summary = f"{variant} pass rate {rate:.1f}% ({passed}/{total}), threshold {threshold:.1f}%"
+    return rate >= threshold, summary
+
+
 def resolve_results_dir(results_dir: str | None) -> Path:
-    results_root = Path.cwd() / "results"
+    results_root = resolve_results_base()
     if results_dir and results_dir != "latest":
         return Path(results_dir)
+
+    if not results_root.is_dir():
+        # Reachable whenever CULTIVAR_RESULTS_DIR points somewhere that does not exist
+        # yet; without this guard iterdir() raises a bare FileNotFoundError.
+        console.print(f"[red]No results directory at {results_root}.[/red]")
+        raise typer.Exit(1)
 
     dirs = sorted(
         [d for d in results_root.iterdir() if d.is_dir() and d.name[0:4].isdigit()],

--- a/evals/hello.py
+++ b/evals/hello.py
@@ -18,7 +18,7 @@ import typer
 import yaml
 from rich.table import Table
 
-from evals.framework.reporting import console
+from evals.framework.reporting import console, resolve_results_base
 from evals.run import RUNNER_CLASSES, run_local, run_remote
 
 app = typer.Typer(pretty_exceptions_enable=False)
@@ -186,7 +186,7 @@ def main(
             variants = valid_variants
 
         run_id = datetime.now().strftime("%Y-%m-%dT%H-%M-%S") + "__hello"
-        run_dir = Path.cwd() / "results" / run_id
+        run_dir = resolve_results_base() / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
 
         with open(run_dir / "tasks.json", "w") as f:

--- a/evals/run.py
+++ b/evals/run.py
@@ -13,13 +13,13 @@ from pathlib import Path
 import typer
 import yaml
 
-from evals.framework.reporting import resolve_skills_base
+from evals.framework.reporting import resolve_results_base, resolve_skills_base
 from evals.runners.claude import ClaudeRunner
 from evals.runners.copilot import CopilotRunner
 from evals.runners.gemini import GeminiRunner
 
 TASKS_DIR = Path.cwd() / "tasks"
-RESULTS_DIR = Path.cwd() / "results"
+RESULTS_DIR = resolve_results_base()
 
 RUNNER_CLASSES = {
     "claude": ClaudeRunner,
@@ -426,6 +426,14 @@ def main(
     grade: bool = typer.Option(
         False, "--grade", help="After runs finish, invoke the grader and print a report. Requires ANTHROPIC_API_KEY."
     ),
+    fail_under: float | None = typer.Option(
+        None,
+        "--fail-under",
+        help=(
+            "With --grade, exit 1 if the with-skill pass rate is below this percentage (0-100). "
+            "Omit to always exit 0. Intended for CI gates."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -556,9 +564,14 @@ def main(
 
     if grade:
         typer.echo("\nGrading...")
-        subprocess.run(
-            [sys.executable, "-m", "evals.cli", "grade", str(run_dir), "--skill", skill, "--report"],
-        )
+        cmd = [sys.executable, "-m", "evals.cli", "grade", str(run_dir), "--skill", skill, "--report"]
+        if fail_under is not None:
+            cmd += ["--fail-under", str(fail_under)]
+        result = subprocess.run(cmd)
+        # Propagate the child's status. Previously discarded, which meant a failing
+        # gate — or a crashed grader — still exited 0 and a CI job went green.
+        if result.returncode != 0:
+            raise typer.Exit(result.returncode)
     else:
         typer.echo("\nTo grade and view report:")
         typer.echo(f"  cultivar grade {run_dir} --report")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1213,3 +1213,158 @@ class TestResolveSkillsBase:
         monkeypatch.chdir(tmp_path)
         abs_dir = tmp_path / "elsewhere" / "skills"
         assert self.resolve(str(abs_dir)) == abs_dir
+
+
+# ---------------------------------------------------------------------------
+# CI gate — results dir resolution, pass-rate math, and the threshold verdict
+# ---------------------------------------------------------------------------
+
+
+class TestResolveResultsBase:
+    """CI points results at $RUNNER_TEMP; getting this wrong writes into the checkout."""
+
+    @staticmethod
+    def resolve():
+        from evals.framework.reporting import resolve_results_base
+
+        return resolve_results_base()
+
+    def test_defaults_to_cwd_results(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CULTIVAR_RESULTS_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve() == tmp_path / "results"
+
+    def test_env_var_overrides_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CULTIVAR_RESULTS_DIR", "out")
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve() == tmp_path / "out"
+
+    def test_absolute_env_value_preserved(self, tmp_path, monkeypatch):
+        elsewhere = tmp_path / "elsewhere" / "out"
+        monkeypatch.setenv("CULTIVAR_RESULTS_DIR", str(elsewhere))
+        monkeypatch.chdir(tmp_path)
+        assert self.resolve() == elsewhere
+
+
+def _grades(*specs):
+    """Build minimal grade rows: each spec is (variant, passed)."""
+    return [
+        {"pass": ok, "variant": v, "task_id": f"t{i}", "runner": "claude", "run_num": 1}
+        for i, (v, ok) in enumerate(specs)
+    ]
+
+
+class TestGatePassRate:
+    """The baseline variant is expected to fail; letting it into the denominator
+    would make every threshold meaningless."""
+
+    @staticmethod
+    def rate(grades, variant="with-skill"):
+        from evals.framework.reporting import gate_pass_rate
+
+        return gate_pass_rate(grades, variant)
+
+    def test_counts_only_the_named_variant(self):
+        g = _grades(
+            ("with-skill", True),
+            ("with-skill", True),
+            ("with-skill", False),
+            ("without-skill", False),
+            ("without-skill", False),
+        )
+        rate, passed, total = self.rate(g)
+        assert (passed, total) == (2, 3)
+        assert rate == pytest.approx(66.67, abs=0.01)
+
+    def test_naive_overall_rate_would_differ(self):
+        """Guards the whole point of the variant filter: 2/5 != 2/3."""
+        g = _grades(
+            ("with-skill", True),
+            ("with-skill", True),
+            ("with-skill", False),
+            ("without-skill", False),
+            ("without-skill", False),
+        )
+        assert self.rate(g)[0] != pytest.approx(40.0)
+
+    def test_all_passing_is_one_hundred(self):
+        assert self.rate(_grades(("with-skill", True), ("with-skill", True)))[0] == 100.0
+
+    def test_empty_variant_yields_zero_not_crash(self):
+        assert self.rate(_grades(("without-skill", True))) == (0.0, 0, 0)
+
+    def test_other_variant_selectable(self):
+        g = _grades(("with-docs", True), ("with-docs", False))
+        assert self.rate(g, "with-docs") == (50.0, 1, 2)
+
+
+class TestGateVerdict:
+    """Exit-code decision. Before this existed, a failing eval still exited 0."""
+
+    @staticmethod
+    def verdict(grades, threshold, variant="with-skill"):
+        from evals.framework.reporting import gate_verdict
+
+        return gate_verdict(grades, threshold, variant)
+
+    def test_above_threshold_passes(self):
+        ok, msg = self.verdict(_grades(("with-skill", True), ("with-skill", True)), 80.0)
+        assert ok
+        assert "100.0%" in msg
+
+    def test_below_threshold_fails(self):
+        ok, msg = self.verdict(_grades(("with-skill", True), ("with-skill", False)), 80.0)
+        assert not ok
+        assert "50.0%" in msg and "80.0%" in msg
+
+    def test_exactly_at_threshold_passes(self):
+        """>= not >, so --fail-under 50 on a 50% run is green."""
+        ok, _ = self.verdict(_grades(("with-skill", True), ("with-skill", False)), 50.0)
+        assert ok
+
+    def test_no_grades_fails_rather_than_vacuously_passing(self):
+        ok, msg = self.verdict([], 0.0)
+        assert not ok
+        assert "no with-skill grades" in msg
+
+    def test_baseline_only_run_fails(self):
+        """A run where the with-skill variant never executed must not read as green."""
+        ok, _ = self.verdict(_grades(("without-skill", True)), 0.0)
+        assert not ok
+
+
+class TestReportFormats:
+    """md/json are consumed by CI, so their shape is a contract."""
+
+    @staticmethod
+    def summarize(grades):
+        from evals.framework.report import _summarize
+
+        return _summarize(grades)
+
+    def test_json_summary_shape(self):
+        s = self.summarize(_grades(("with-skill", True), ("with-skill", False)))
+        assert s["total_conversations"] == 2
+        assert s["variants"]["with-skill"] == {"pass_rate": 50.0, "passed": 1, "total": 2}
+        assert len(s["failures"]) == 1
+
+    def test_variants_ordered_predictably(self):
+        s = self.summarize(_grades(("without-skill", False), ("with-skill", True)))
+        assert list(s["variants"]) == ["with-skill", "without-skill"]
+
+    def test_unknown_variant_still_reported(self):
+        s = self.summarize(_grades(("with-skill", True), ("custom", False)))
+        assert "custom" in s["variants"]
+
+    def test_md_renders_table_and_failures(self):
+        from evals.framework.report import _render_md
+
+        md = _render_md(_grades(("with-skill", False)), "run-x")
+        assert "run-x" in md
+        assert "| `with-skill` | 0.0% | 0 | 1 |" in md
+        assert "1 failure(s)" in md
+
+    def test_md_says_no_failures_when_clean(self):
+        from evals.framework.report import _render_md
+
+        assert "No failures." in _render_md(_grades(("with-skill", True)), "run-y")


### PR DESCRIPTION
Three changes so cultivar can gate CI.

## 1. Exit codes

There was no `sys.exit` anywhere in `evals/`. `grade` wrote `grades.json` and
returned; `run --grade` discarded the child's return code. A CI job went green
regardless of results.

Adds `--fail-under PCT` and `--gate-variant` to `grade`, threads both through
`run --grade`, and propagates the child status.

The gate measures the **with-skill variant only**. without-skill is the baseline
and is expected to fail, so folding it in makes any threshold meaningless: on a
2/3 with-skill run, a naive overall rate reads 40% instead of 66.7%.

An empty result set fails rather than passing vacuously — that usually means the
runner or the task filter broke, which is the case you least want reported as
success.

The decision lives in `gate_verdict()` so it stays pure and testable; the CLI only
prints and exits.

## 2. `report --format md|json`

`md` is sized for a PR comment or `$GITHUB_STEP_SUMMARY`. `json` is flat and
append-only, for trend records.

Both bypass Rich, which would otherwise inject markup and wrap to terminal width —
either corrupts piped output.

## 3. `CULTIVAR_RESULTS_DIR`

Mirrors the existing `CULTIVAR_SKILLS_DIR` precedence in `reporting.py`, so CI can
write runs to `$RUNNER_TEMP` instead of the checkout. Covers `run.py`, `hello.py`,
and `resolve_results_dir`.

Also guards a missing results root, which previously raised a bare
`FileNotFoundError` — newly reachable now that an env var can point somewhere that
doesn't exist yet.

---

18 new tests; suite goes 92 → 110. No API keys needed to run them.
