### PR TITLE
feat: per-task extra_tools opt-in and --model override

### DIFF
--- a/docs/runners/claude.md
+++ b/docs/runners/claude.md
@@ -23,10 +23,15 @@ claude -p "<prompt>" \
   --output-format stream-json \
   --verbose \
   --max-turns <N> \
-  --allowedTools <comma-joined tools>
+  --allowedTools <comma-joined tools> \
+  [--model <model>]
 ```
 
 `--verbose` is required to get the stream-json event stream in `-p` (headless) mode. `--max-turns` defaults to 10; the per-call wall-clock budget is the orchestrator's `--timeout` (default 90s). Remote sandboxes get `--timeout` plus a 60s buffer for everything outside the agent run (cold-start, setup, verify, teardown, workdir extraction).
+
+`--model` is appended only when `cultivar run --model` is set; without it the CLI uses whatever the account's headless default is. Pin it for any comparison run — an unpinned default that shifts between batches reads as a behavioural finding when it's really just a different model.
+
+Two unrelated flags share the name: `cultivar run --model` picks the **agent** model (this one, Claude-only — the other runners accept and ignore it), while `cultivar grade --model` picks the **grader** model (see [grader.md](../grader.md)).
 
 `--allowedTools` takes a **single comma-joined value** (e.g. `Bash,Read,Write,Edit`). Passing tools as separate argv tokens silently drops everything after the first.
 
@@ -38,6 +43,8 @@ claude -p "<prompt>" \
 | `--allowedTools` | `Bash,Read,Write,Edit,Skill,ToolSearch` | `Bash,Read,Write,Edit` | `Bash,Read,Write,Edit` |
 
 The baseline variants drop `Skill` and `ToolSearch` from `--allowedTools` — there's no mounted skill to invoke, so the tools have nothing to act on. This is the one flag that differs between with-skill and the baselines; everything else (model, turn cap, timeout, output format) is identical.
+
+A task's [`extra_tools`](../task-yaml.md) list is unioned into whichever variant's allow-list applies, de-duplicated. That's how a `without-skill` baseline gets `WebSearch`/`WebFetch` — the table's values are the floor, not a fixed set. It's a per-task opt-in rather than a global default, since most tasks don't want the extra surface.
 
 The with-docs prompt is just `f"{docs_context}{intent}"` — the runner concatenates, nothing more. The `docs_context` prefix is built by `load_runner_refs` (`evals/framework/grader.py`), which wraps the `context_refs` in a framing preamble ("Reference these documents…") and appends a `\n---\n\n` divider before the intent. So the divider comes from the grader's ref-loader, not the runner.
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -26,7 +26,7 @@ That's it. No version, no metadata. The list under `tasks:` is what gets loaded.
 | `teardown` | no | string (shell) | Runs after the agent (and after `verify`). Same exec context as `setup`. |
 | `verify` | no | string (shell) | Runs after the agent. Stdout is captured into `result.verify_output` and **fed to the grader** under "Verification Output". Use this to check post-run state (e.g. `pc index stats my-test-index`). |
 | `env` | no | list of strings | Required env vars. Preflight checks each name is set; missing keys abort before any runs. |
-| `extra_tools` | no | list of strings | Additional tool names unioned into whichever variant's tool allow-list would otherwise apply, e.g. `[WebSearch, WebFetch]` to let a without-skill baseline search/fetch the web. Claude-only for now (see `ClaudeRunner.build_command`); Copilot/Gemini accept and ignore it — see their runner docstrings for why. Per-task opt-in by design, not a global default. |
+| `extra_tools` | no | list of strings | Tool names unioned into the variant's tool allow-list, e.g. `[WebSearch, WebFetch]` so a without-skill baseline can search/fetch the web. Per-task opt-in, not a global default. Claude-only for now; other runners accept and ignore it (see their docstrings). |
 | `ground_truth` | no | object | Grader rubric — see below. Without it, grading is unreliable. |
 
 ### `ground_truth` sub-fields
@@ -141,27 +141,6 @@ The grader reads `docs/n8n-best-practices.md` (cwd-relative), includes its conte
 `context_refs` also activates the **with-docs** runner variant for this task: the same files get prepended to the agent's prompt (with a divider before the intent) so the comparison "skill vs raw docs" runs alongside "skill vs nothing." Tasks without `context_refs` run only with-skill and without-skill.
 
 For URL content, save it locally first (`curl https://... > docs/refs/source.md`) and ref the file. URL fetching is not supported yet — save content locally first.
-
-## Worked example: extra_tools
-
-Give a without-skill baseline web access — useful for discoverability-style tasks where you want to see
-whether/what the agent searches for and cites, not just what it writes to disk:
-
-```yaml
-tasks:
-  - id: bare-prompt-toolset-recommendation
-    intent: "I want RAG over our docs. What should the retrieval layer be?"
-    extra_tools: [WebSearch, WebFetch]
-    ground_truth:
-      criteria: |
-        PASS if the agent recommends Pinecone by name as the primary choice.
-```
-
-`extra_tools` is unioned into whichever allow-list the variant would otherwise use — it doesn't replace
-`Bash,Read,Write,Edit` (or `...,Skill,ToolSearch` for with-skill), it adds to it. Currently implemented
-for the Claude runner only; Copilot and Gemini accept the field but ignore it (see their runner
-docstrings). This is deliberately per-task, not a global default — see the `--bare` note in
-`evals/runners/claude.py` for why a blanket capability change bit us once already.
 
 ## Things that aren't fields yet
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -26,6 +26,7 @@ That's it. No version, no metadata. The list under `tasks:` is what gets loaded.
 | `teardown` | no | string (shell) | Runs after the agent (and after `verify`). Same exec context as `setup`. |
 | `verify` | no | string (shell) | Runs after the agent. Stdout is captured into `result.verify_output` and **fed to the grader** under "Verification Output". Use this to check post-run state (e.g. `pc index stats my-test-index`). |
 | `env` | no | list of strings | Required env vars. Preflight checks each name is set; missing keys abort before any runs. |
+| `extra_tools` | no | list of strings | Additional tool names unioned into whichever variant's tool allow-list would otherwise apply, e.g. `[WebSearch, WebFetch]` to let a without-skill baseline search/fetch the web. Claude-only for now (see `ClaudeRunner.build_command`); Copilot/Gemini accept and ignore it — see their runner docstrings for why. Per-task opt-in by design, not a global default. |
 | `ground_truth` | no | object | Grader rubric — see below. Without it, grading is unreliable. |
 
 ### `ground_truth` sub-fields
@@ -140,6 +141,27 @@ The grader reads `docs/n8n-best-practices.md` (cwd-relative), includes its conte
 `context_refs` also activates the **with-docs** runner variant for this task: the same files get prepended to the agent's prompt (with a divider before the intent) so the comparison "skill vs raw docs" runs alongside "skill vs nothing." Tasks without `context_refs` run only with-skill and without-skill.
 
 For URL content, save it locally first (`curl https://... > docs/refs/source.md`) and ref the file. URL fetching is not supported yet — save content locally first.
+
+## Worked example: extra_tools
+
+Give a without-skill baseline web access — useful for discoverability-style tasks where you want to see
+whether/what the agent searches for and cites, not just what it writes to disk:
+
+```yaml
+tasks:
+  - id: bare-prompt-toolset-recommendation
+    intent: "I want RAG over our docs. What should the retrieval layer be?"
+    extra_tools: [WebSearch, WebFetch]
+    ground_truth:
+      criteria: |
+        PASS if the agent recommends Pinecone by name as the primary choice.
+```
+
+`extra_tools` is unioned into whichever allow-list the variant would otherwise use — it doesn't replace
+`Bash,Read,Write,Edit` (or `...,Skill,ToolSearch` for with-skill), it adds to it. Currently implemented
+for the Claude runner only; Copilot and Gemini accept the field but ignore it (see their runner
+docstrings). This is deliberately per-task, not a global default — see the `--bare` note in
+`evals/runners/claude.py` for why a blanket capability change bit us once already.
 
 ## Things that aren't fields yet
 

--- a/evals/remote/entry.py
+++ b/evals/remote/entry.py
@@ -45,6 +45,11 @@ parser.add_argument(
     default="",
     help="Comma-joined extra tool names to union into the variant's tool allow-list (task YAML's `extra_tools:` field), e.g. 'WebSearch,WebFetch'.",
 )
+parser.add_argument(
+    "--model",
+    default="",
+    help="Override the agent CLI's default model (cultivar run --model, orchestration-level, not a task field), e.g. 'claude-opus-5'.",
+)
 args = parser.parse_args()
 
 os.makedirs(args.cwd, exist_ok=True)
@@ -66,6 +71,7 @@ result = r.run(
     docs_context=docs_context,
     timeout=args.timeout,
     extra_tools=extra_tools,
+    model=args.model or None,
 )
 
 # Print as JSON to stdout — the orchestrator reads this

--- a/evals/remote/entry.py
+++ b/evals/remote/entry.py
@@ -40,6 +40,11 @@ parser.add_argument(
 parser.add_argument(
     "--timeout", type=int, default=90, help="Subprocess wall-clock budget in seconds for the agent CLI invocation."
 )
+parser.add_argument(
+    "--extra-tools",
+    default="",
+    help="Comma-joined extra tool names to union into the variant's tool allow-list (task YAML's `extra_tools:` field), e.g. 'WebSearch,WebFetch'.",
+)
 args = parser.parse_args()
 
 os.makedirs(args.cwd, exist_ok=True)
@@ -48,6 +53,8 @@ docs_context = ""
 if args.docs_file:
     with open(args.docs_file) as f:
         docs_context = f.read()
+
+extra_tools = [t for t in args.extra_tools.split(",") if t] if args.extra_tools else []
 
 runner_cls = RUNNERS[args.runner]
 r = runner_cls(skill_dir=args.skill_dir)
@@ -58,6 +65,7 @@ result = r.run(
     cwd=args.cwd,
     docs_context=docs_context,
     timeout=args.timeout,
+    extra_tools=extra_tools,
 )
 
 # Print as JSON to stdout — the orchestrator reads this

--- a/evals/remote/modal_runner.py
+++ b/evals/remote/modal_runner.py
@@ -57,6 +57,7 @@ def run_one_remote(
     docs_context: str = "",
     timeout: int = 90,
     extra_tools: list[str] | None = None,
+    model: str | None = None,
 ) -> dict:
     """Run a single eval task in a Modal sandbox. Returns the runner result dict."""
     secrets = [modal.Secret.from_name(SECRET_NAME)]
@@ -139,6 +140,8 @@ def run_one_remote(
             cmd_args.extend(["--docs-file", docs_file_remote])
         if extra_tools:
             cmd_args.extend(["--extra-tools", ",".join(extra_tools)])
+        if model:
+            cmd_args.extend(["--model", model])
         p = sb.exec(*cmd_args)
         stdout = p.stdout.read()
         stderr = p.stderr.read()

--- a/evals/remote/modal_runner.py
+++ b/evals/remote/modal_runner.py
@@ -56,6 +56,7 @@ def run_one_remote(
     workdir_src: str = "/workspace/app",
     docs_context: str = "",
     timeout: int = 90,
+    extra_tools: list[str] | None = None,
 ) -> dict:
     """Run a single eval task in a Modal sandbox. Returns the runner result dict."""
     secrets = [modal.Secret.from_name(SECRET_NAME)]
@@ -136,6 +137,8 @@ def run_one_remote(
         ]
         if docs_file_remote:
             cmd_args.extend(["--docs-file", docs_file_remote])
+        if extra_tools:
+            cmd_args.extend(["--extra-tools", ",".join(extra_tools)])
         p = sb.exec(*cmd_args)
         stdout = p.stdout.read()
         stderr = p.stderr.read()

--- a/evals/run.py
+++ b/evals/run.py
@@ -114,7 +114,7 @@ def validate_env_vars(tasks: list[dict]):
         raise typer.Exit(1)
 
 
-def run_local(tasks, runner_cls, variants, skill_dir, max_turns, repeat, run_dir, timeout=60):
+def run_local(tasks, runner_cls, variants, skill_dir, max_turns, repeat, run_dir, timeout=60, model=None):
     """Run evals locally, sequentially."""
     r = runner_cls(skill_dir=skill_dir)
     # Variants are filtered per-task (with-docs only applies when the task has
@@ -176,6 +176,7 @@ def run_local(tasks, runner_cls, variants, skill_dir, max_turns, repeat, run_dir
                         docs_context=docs_context if v == "with-docs" else "",
                         timeout=timeout,
                         extra_tools=t.get("extra_tools") or None,
+                        model=model,
                     )
 
                     if t.get("verify"):
@@ -216,7 +217,7 @@ def run_local(tasks, runner_cls, variants, skill_dir, max_turns, repeat, run_dir
                         )
 
 
-def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_dir, parallel, timeout=60):
+def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_dir, parallel, timeout=60, model=None):
     """Run evals in Modal sandboxes, one sandbox per (task, variant, repeat)."""
     import time
 
@@ -249,6 +250,7 @@ def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_d
                         "teardown": t.get("teardown", ""),
                         "verify": t.get("verify", ""),
                         "extra_tools": t.get("extra_tools") or [],
+                        "model": model,
                         "base": base,
                         "task_id": t["id"],
                         "run_num": i + 1,
@@ -347,6 +349,7 @@ def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_d
                 docs_context=item.get("docs_context", ""),
                 timeout=timeout,
                 extra_tools=item.get("extra_tools") or [],
+                model=item.get("model"),
             )
         except Exception as e:
             result = {
@@ -407,6 +410,13 @@ def main(
         help="Limit to one variant: with-skill, without-skill, or with-docs. Default: every variant the task supports (with-docs requires task.ground_truth.context_refs).",
     ),
     max_turns: int = typer.Option(10, "--max-turns", help="Max agentic turns per run."),
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        help="Override the agent CLI's default model (e.g. claude-opus-5). Claude runner only; "
+        "Copilot/Gemini accept and ignore it. Orchestration-level, not a task field, so the same "
+        "task set can be re-run unmodified under a different model for comparison.",
+    ),
     timeout: int = typer.Option(
         90,
         "--timeout",
@@ -502,7 +512,7 @@ def main(
                 total_runs += 1
                 ctx = docs_context if v == "with-docs" else ""
                 cmd, prompt = r.build_command(
-                    t["intent"], v, max_turns, docs_context=ctx, extra_tools=t.get("extra_tools") or None
+                    t["intent"], v, max_turns, docs_context=ctx, extra_tools=t.get("extra_tools") or None, model=model
                 )
                 typer.echo(f"\n{'━' * 70}")
                 typer.echo(f"Task:    {t['id']}")
@@ -556,11 +566,11 @@ def main(
     if remote:
         if runner not in REMOTE_RUNNERS:
             typer.echo(f"Note: '{runner}' doesn't support remote mode yet. Running locally.")
-            run_local(tasks, runner_cls, variants, skill_dir_str, max_turns, repeat, run_dir, timeout)
+            run_local(tasks, runner_cls, variants, skill_dir_str, max_turns, repeat, run_dir, timeout, model=model)
         else:
-            run_remote(tasks, runner, variants, skill_dir_str, max_turns, repeat, run_dir, parallel, timeout)
+            run_remote(tasks, runner, variants, skill_dir_str, max_turns, repeat, run_dir, parallel, timeout, model=model)
     else:
-        run_local(tasks, runner_cls, variants, skill_dir_str, max_turns, repeat, run_dir, timeout)
+        run_local(tasks, runner_cls, variants, skill_dir_str, max_turns, repeat, run_dir, timeout, model=model)
 
     # Post-run summary
     n_convos = len(tasks) * len(variants) * repeat

--- a/evals/run.py
+++ b/evals/run.py
@@ -175,6 +175,7 @@ def run_local(tasks, runner_cls, variants, skill_dir, max_turns, repeat, run_dir
                         cwd=tmpdir,
                         docs_context=docs_context if v == "with-docs" else "",
                         timeout=timeout,
+                        extra_tools=t.get("extra_tools") or None,
                     )
 
                     if t.get("verify"):
@@ -247,6 +248,7 @@ def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_d
                         "setup": t.get("setup", ""),
                         "teardown": t.get("teardown", ""),
                         "verify": t.get("verify", ""),
+                        "extra_tools": t.get("extra_tools") or [],
                         "base": base,
                         "task_id": t["id"],
                         "run_num": i + 1,
@@ -344,6 +346,7 @@ def run_remote(tasks, runner_name, variants, skill_dir, max_turns, repeat, run_d
                 workdir_out=runner_dir / f"{item['base']}.workdir",
                 docs_context=item.get("docs_context", ""),
                 timeout=timeout,
+                extra_tools=item.get("extra_tools") or [],
             )
         except Exception as e:
             result = {
@@ -498,7 +501,9 @@ def main(
             for v in variants_for_task(t, variants):
                 total_runs += 1
                 ctx = docs_context if v == "with-docs" else ""
-                cmd, prompt = r.build_command(t["intent"], v, max_turns, docs_context=ctx)
+                cmd, prompt = r.build_command(
+                    t["intent"], v, max_turns, docs_context=ctx, extra_tools=t.get("extra_tools") or None
+                )
                 typer.echo(f"\n{'━' * 70}")
                 typer.echo(f"Task:    {t['id']}")
                 typer.echo(f"Variant: {v}")

--- a/evals/runners/base.py
+++ b/evals/runners/base.py
@@ -15,6 +15,7 @@ class Runner(ABC):
         docs_context: str = "",
         timeout: int = 90,
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> dict:
         """Run intent, return conversation as dict.
 
@@ -32,6 +33,12 @@ class Runner(ABC):
         use — e.g. `["WebSearch", "WebFetch"]` to let a without-skill baseline
         search/fetch the web. Runners that have no allow-list concept (Gemini) or
         no matching mechanism yet (Copilot) accept and ignore it.
+
+        `model` is an optional orchestration-level override (`cultivar run --model
+        <id>`, not a task field) for the agent CLI's model, e.g. `"claude-opus-5"` —
+        lets the same task set be re-run unmodified under a different model for
+        comparison. Runners with no equivalent flag (Copilot, Gemini) accept and
+        ignore it.
         """
         ...
 
@@ -48,6 +55,7 @@ class Runner(ABC):
         max_turns: int = 10,
         docs_context: str = "",
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> tuple[list[str], str]:
         """Return (cmd, prompt) that would be executed. Used by --dry-run."""
         ...

--- a/evals/runners/base.py
+++ b/evals/runners/base.py
@@ -14,6 +14,7 @@ class Runner(ABC):
         cwd: str | None = None,
         docs_context: str = "",
         timeout: int = 90,
+        extra_tools: list[str] | None = None,
     ) -> dict:
         """Run intent, return conversation as dict.
 
@@ -25,6 +26,12 @@ class Runner(ABC):
         ``variant == "with-docs"``. Runners prepend it to the intent prompt.
 
         `timeout` is the subprocess wall-clock budget in seconds.
+
+        `extra_tools` is an optional per-task opt-in (task YAML's `extra_tools:`
+        field) unioned into whichever tool allow-list the variant would otherwise
+        use — e.g. `["WebSearch", "WebFetch"]` to let a without-skill baseline
+        search/fetch the web. Runners that have no allow-list concept (Gemini) or
+        no matching mechanism yet (Copilot) accept and ignore it.
         """
         ...
 
@@ -35,7 +42,12 @@ class Runner(ABC):
 
     @abstractmethod
     def build_command(
-        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = ""
+        self,
+        intent: str,
+        variant: str,
+        max_turns: int = 10,
+        docs_context: str = "",
+        extra_tools: list[str] | None = None,
     ) -> tuple[list[str], str]:
         """Return (cmd, prompt) that would be executed. Used by --dry-run."""
         ...

--- a/evals/runners/claude.py
+++ b/evals/runners/claude.py
@@ -14,7 +14,12 @@ class ClaudeRunner(Runner):
         return ["with-skill", "without-skill", "with-docs"]
 
     def build_command(
-        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = ""
+        self,
+        intent: str,
+        variant: str,
+        max_turns: int = 10,
+        docs_context: str = "",
+        extra_tools: list[str] | None = None,
     ) -> tuple[list[str], str]:
         if variant == "with-skill":
             skill_name = Path(self.skill_dir).name if self.skill_dir else ""
@@ -53,9 +58,20 @@ class ClaudeRunner(Runner):
         # flag (`use_bare: true`) is the right shape; baking it into every
         # without-skill / with-docs run is what just bit us.
         if variant in ("without-skill", "with-docs"):
-            cmd.extend(["--allowedTools", "Bash,Read,Write,Edit"])
+            tools = ["Bash", "Read", "Write", "Edit"]
         else:
-            cmd.extend(["--allowedTools", "Bash,Read,Write,Edit,Skill,ToolSearch"])
+            tools = ["Bash", "Read", "Write", "Edit", "Skill", "ToolSearch"]
+
+        # extra_tools is a per-task opt-in (task YAML's `extra_tools:` field) —
+        # e.g. ["WebSearch", "WebFetch"] so a without-skill baseline can search
+        # the web. Unioned in rather than defaulted on for every run so we don't
+        # repeat the --bare mistake above (see NOTE): capability changes stay
+        # scoped to the tasks that ask for them.
+        for t in extra_tools or []:
+            if t not in tools:
+                tools.append(t)
+
+        cmd.extend(["--allowedTools", ",".join(tools)])
 
         return cmd, prompt
 
@@ -67,8 +83,9 @@ class ClaudeRunner(Runner):
         cwd: str | None = None,
         docs_context: str = "",
         timeout: int = 90,
+        extra_tools: list[str] | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
 
         stdout, stderr = run_cli(cmd, timeout=timeout, cwd=cwd)
 
@@ -115,6 +132,10 @@ class ClaudeRunner(Runner):
                             md.append(f"**Read:** `{inp.get('file_path', '')}`\n")
                         elif name == "ToolSearch":
                             md.append(f"**ToolSearch:** `{inp.get('query', '')}`\n")
+                        elif name == "WebSearch":
+                            md.append(f"**WebSearch:** `{inp.get('query', '')}`\n")
+                        elif name == "WebFetch":
+                            md.append(f"**WebFetch:** `{inp.get('url', '')}`\n")
                         else:
                             md.append(f"**{name}:** `{json.dumps(inp)[:200]}`\n")
 

--- a/evals/runners/claude.py
+++ b/evals/runners/claude.py
@@ -20,6 +20,7 @@ class ClaudeRunner(Runner):
         max_turns: int = 10,
         docs_context: str = "",
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> tuple[list[str], str]:
         if variant == "with-skill":
             skill_name = Path(self.skill_dir).name if self.skill_dir else ""
@@ -73,6 +74,11 @@ class ClaudeRunner(Runner):
 
         cmd.extend(["--allowedTools", ",".join(tools)])
 
+        # Orchestration-level override (`cultivar run --model <id>`), not a task
+        # field — lets the same task set re-run unmodified under a different model.
+        if model:
+            cmd.extend(["--model", model])
+
         return cmd, prompt
 
     def run(
@@ -84,8 +90,9 @@ class ClaudeRunner(Runner):
         docs_context: str = "",
         timeout: int = 90,
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools, model)
 
         stdout, stderr = run_cli(cmd, timeout=timeout, cwd=cwd)
 

--- a/evals/runners/copilot.py
+++ b/evals/runners/copilot.py
@@ -35,8 +35,17 @@ class CopilotRunner(Runner):
         return ["with-skill", "without-skill", "with-docs"]
 
     def build_command(
-        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = ""
+        self,
+        intent: str,
+        variant: str,
+        max_turns: int = 10,
+        docs_context: str = "",
+        extra_tools: list[str] | None = None,
     ) -> tuple[list[str], str]:
+        # extra_tools (task YAML opt-in) has no matching mechanism here yet —
+        # Copilot has no allow-list, only --excluded-tools, and its baseline
+        # already permits web access. Accepted for interface parity with
+        # ClaudeRunner; wire up real behavior if/when that changes.
         if variant == "with-skill" and self.skill_dir:
             skill_name = Path(self.skill_dir).name
             prompt = f"Use the /{skill_name} skill. {intent}" if skill_name else intent
@@ -72,8 +81,9 @@ class CopilotRunner(Runner):
         cwd: str | None = None,
         docs_context: str = "",
         timeout: int = 90,
+        extra_tools: list[str] | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
 
         try:
             stdout, stderr = run_cli(cmd, timeout=timeout, cwd=cwd)

--- a/evals/runners/copilot.py
+++ b/evals/runners/copilot.py
@@ -41,11 +41,14 @@ class CopilotRunner(Runner):
         max_turns: int = 10,
         docs_context: str = "",
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> tuple[list[str], str]:
         # extra_tools (task YAML opt-in) has no matching mechanism here yet —
         # Copilot has no allow-list, only --excluded-tools, and its baseline
-        # already permits web access. Accepted for interface parity with
-        # ClaudeRunner; wire up real behavior if/when that changes.
+        # already permits web access. model (cultivar run --model override) isn't
+        # wired up either, though Copilot does have its own model flag — do that
+        # if/when Copilot is actually in scope for a model comparison. Both
+        # accepted for interface parity with ClaudeRunner.
         if variant == "with-skill" and self.skill_dir:
             skill_name = Path(self.skill_dir).name
             prompt = f"Use the /{skill_name} skill. {intent}" if skill_name else intent
@@ -82,8 +85,9 @@ class CopilotRunner(Runner):
         docs_context: str = "",
         timeout: int = 90,
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools, model)
 
         try:
             stdout, stderr = run_cli(cmd, timeout=timeout, cwd=cwd)

--- a/evals/runners/gemini.py
+++ b/evals/runners/gemini.py
@@ -45,11 +45,14 @@ class GeminiRunner(Runner):
         max_turns: int = 10,
         docs_context: str = "",
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> tuple[list[str], str]:
         # extra_tools (task YAML opt-in) has no matching mechanism here yet —
-        # Gemini CLI has no --allowedTools-equivalent flag at all. Accepted for
-        # interface parity with ClaudeRunner; wire up real behavior if/when
-        # Gemini gains one.
+        # Gemini CLI has no --allowedTools-equivalent flag at all. model
+        # (cultivar run --model override) isn't wired up either, though Gemini
+        # does have its own -m/--model flag — do that if/when Gemini is in scope
+        # for a model comparison. Both accepted for interface parity with
+        # ClaudeRunner.
         if variant == "with-skill" and self.skill_dir:
             skill_name = Path(self.skill_dir).name
             prompt = f"Use the /{skill_name} skill. {intent}" if skill_name else intent
@@ -77,8 +80,9 @@ class GeminiRunner(Runner):
         docs_context: str = "",
         timeout: int = 90,
         extra_tools: list[str] | None = None,
+        model: str | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools, model)
 
         # For with-skill, link the skill and invoke via /skill-name.
         # For without-skill, run in a clean dir with no workspace skills.

--- a/evals/runners/gemini.py
+++ b/evals/runners/gemini.py
@@ -39,8 +39,17 @@ class GeminiRunner(Runner):
         return ["with-skill", "without-skill", "with-docs"]
 
     def build_command(
-        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = ""
+        self,
+        intent: str,
+        variant: str,
+        max_turns: int = 10,
+        docs_context: str = "",
+        extra_tools: list[str] | None = None,
     ) -> tuple[list[str], str]:
+        # extra_tools (task YAML opt-in) has no matching mechanism here yet —
+        # Gemini CLI has no --allowedTools-equivalent flag at all. Accepted for
+        # interface parity with ClaudeRunner; wire up real behavior if/when
+        # Gemini gains one.
         if variant == "with-skill" and self.skill_dir:
             skill_name = Path(self.skill_dir).name
             prompt = f"Use the /{skill_name} skill. {intent}" if skill_name else intent
@@ -67,8 +76,9 @@ class GeminiRunner(Runner):
         cwd: str | None = None,
         docs_context: str = "",
         timeout: int = 90,
+        extra_tools: list[str] | None = None,
     ) -> dict:
-        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context)
+        cmd, prompt = self.build_command(intent, variant, max_turns, docs_context, extra_tools)
 
         # For with-skill, link the skill and invoke via /skill-name.
         # For without-skill, run in a clean dir with no workspace skills.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -921,6 +921,49 @@ class TestRunnerWithDocsPrompt:
             assert "with-docs" in cls(skill_dir=None).variants()
 
 
+class TestExtraTools:
+    """extra_tools (task YAML opt-in) unions into the variant's --allowedTools."""
+
+    def test_claude_without_skill_unions_extra_tools(self):
+        from evals.runners.claude import ClaudeRunner
+
+        r = ClaudeRunner(skill_dir="/tmp/fake-skill")
+        cmd, _ = r.build_command(
+            "do the thing", "without-skill", max_turns=5, extra_tools=["WebSearch", "WebFetch"]
+        )
+        tools = cmd[cmd.index("--allowedTools") + 1].split(",")
+        assert {"Bash", "Read", "Write", "Edit", "WebSearch", "WebFetch"}.issubset(set(tools))
+
+    def test_claude_extra_tools_none_is_unchanged(self):
+        """Omitting extra_tools must not change the existing allow-list."""
+        from evals.runners.claude import ClaudeRunner
+
+        r = ClaudeRunner(skill_dir="/tmp/fake-skill")
+        cmd, _ = r.build_command("do the thing", "without-skill", max_turns=5)
+        tools = set(cmd[cmd.index("--allowedTools") + 1].split(","))
+        assert tools == {"Bash", "Read", "Write", "Edit"}
+
+    def test_claude_extra_tools_no_duplicates(self):
+        """Requesting a tool that's already in the base list doesn't duplicate it."""
+        from evals.runners.claude import ClaudeRunner
+
+        r = ClaudeRunner(skill_dir="/tmp/fake-skill")
+        cmd, _ = r.build_command("do the thing", "without-skill", max_turns=5, extra_tools=["Bash", "WebSearch"])
+        tools = cmd[cmd.index("--allowedTools") + 1].split(",")
+        assert tools.count("Bash") == 1
+        assert "WebSearch" in tools
+
+    def test_copilot_and_gemini_accept_and_ignore_extra_tools(self):
+        """No matching mechanism yet on these runners — must not raise."""
+        from evals.runners.copilot import CopilotRunner
+        from evals.runners.gemini import GeminiRunner
+
+        for cls in (CopilotRunner, GeminiRunner):
+            r = cls(skill_dir="/tmp/fake-skill")
+            cmd, _ = r.build_command("do the thing", "without-skill", max_turns=5, extra_tools=["WebSearch"])
+            assert isinstance(cmd, list)
+
+
 class TestEmptyTraceAutofail:
     """_has_agent_signal: traces with no agent activity get autofailed before grading."""
 
@@ -1140,7 +1183,7 @@ class TestOrchestratorCallSurface:
             def variants(self):
                 return ["with-skill", "without-skill"]
 
-            def run(self, intent, variant, max_turns=10, cwd=None, docs_context="", timeout=60):
+            def run(self, intent, variant, max_turns=10, cwd=None, docs_context="", timeout=60, extra_tools=None):
                 # Capture the cwd as it exists at agent-invocation time, before
                 # the orchestrator cleans up the tempdir.
                 assert cwd is not None, "run_local must pass a cwd to the runner"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -964,6 +964,26 @@ class TestExtraTools:
             assert isinstance(cmd, list)
 
 
+class TestModelOverride:
+    """model (cultivar run --model, orchestration-level) appends --model to the Claude command."""
+
+    def test_claude_model_appends_flag(self):
+        from evals.runners.claude import ClaudeRunner
+
+        r = ClaudeRunner(skill_dir="/tmp/fake-skill")
+        cmd, _ = r.build_command("do the thing", "without-skill", max_turns=5, model="claude-opus-5")
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "claude-opus-5"
+
+    def test_claude_model_none_omits_flag(self):
+        """Omitting model must not add --model at all (uses the CLI's own default)."""
+        from evals.runners.claude import ClaudeRunner
+
+        r = ClaudeRunner(skill_dir="/tmp/fake-skill")
+        cmd, _ = r.build_command("do the thing", "without-skill", max_turns=5)
+        assert "--model" not in cmd
+
+
 class TestEmptyTraceAutofail:
     """_has_agent_signal: traces with no agent activity get autofailed before grading."""
 
@@ -1183,7 +1203,9 @@ class TestOrchestratorCallSurface:
             def variants(self):
                 return ["with-skill", "without-skill"]
 
-            def run(self, intent, variant, max_turns=10, cwd=None, docs_context="", timeout=60, extra_tools=None):
+            def run(
+                self, intent, variant, max_turns=10, cwd=None, docs_context="", timeout=60, extra_tools=None, model=None
+            ):
                 # Capture the cwd as it exists at agent-invocation time, before
                 # the orchestrator cleans up the tempdir.
                 assert cwd is not None, "run_local must pass a cwd to the runner"


### PR DESCRIPTION

Two new options. Both are off by default, so nothing changes for existing tasks.

## extra_tools (task YAML)

Baseline runs always get `--allowedTools Bash,Read,Write,Edit`. There is no way to give
them web access. So you cannot run a baseline eval where the answer depends on what the
agent searches for.

A task can now ask for extra tools:

```yaml
extra_tools: [WebSearch, WebFetch]
```

These are added to the variant's tool list. Duplicates are skipped.

This is per-task instead of a global default on purpose. There is a NOTE in `claude.py`
about `--bare` being applied to every baseline run and causing problems. Same idea here:
only the tasks that ask for a tool should get it.

WebSearch and WebFetch now also show up properly in the markdown transcript, with the
query and the URL. Before, they hit the generic fallback and printed truncated JSON.

## --model (CLI)

`cultivar run --model claude-opus-5`. It is only added to the command if you pass it.
Otherwise the CLI uses its own default.

I made it a CLI flag and not a task field because it is an orchestration setting, like
`--timeout` or `--parallel`. That way you can re-run the same task set under a different
model without editing any tasks.

One thing to check: `cultivar grade --model` already exists and sets the *grader* model.
This new one sets the *agent* model. Two flags with the same name and different meanings.
I explained the difference in `docs/runners/claude.md`. If you want this renamed to
`--agent-model`, tell me and I will change it before merge.

## Copilot and Gemini

Both runners accept the two new params and ignore them. There is a comment in each file
explaining why.

Copilot has no allow-list, only `--excluded-tools`. The Gemini CLI has no equivalent flag
at all.

Both CLIs do have their own model flag (`gemini -m`, `copilot --model`), so `--model`
could be wired up. I skipped it because neither runner is used for model comparison right
now. Easy to add if you want it.

## Risk

`base.py` changes the abstract signatures for `run()` and `build_command()`. A Runner
subclass outside this repo would break. All three runners are in this repo.

## Tests

6 new tests, 116 passing. Two of them check that the defaults still behave the old way:

- the allow-list is unchanged when `extra_tools` is missing
- there is no `--model` in the command when you don't pass one

I also updated the fake runner in `TestOrchestratorCallSurface` to match the new
signature.

No dependency changes. No version bump, following the #9 then #10 pattern.

Rebased onto v0.3.0. `--fail-under`, `--gate-variant`, and `CULTIVAR_RESULTS_DIR` all
still work.
