### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultivar"
-version = "0.3.0"
+version = "0.4.0"
 description = "Eval framework for testing whether agent skills improve behavior across coding CLIs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "cultivar"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps `version` to `0.4.0` in `pyproject.toml` and `uv.lock`.

Minor rather than patch: #11 added the `extra_tools` task field and `run --model`.
Both are opt-in and backwards compatible.

Merging this does not publish. Pushing the `v0.4.0` tag afterwards is what
triggers `publish.yml`.

`uv lock --check` clean, 116 tests passing.