### PR TITLE
ci: add ruff lint + pip-audit + least-priv permissions + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,25 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run ruff
+        run: uv run --group lint ruff check .
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -23,3 +41,20 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest
+
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run pip-audit
+        run: |
+          uv export --format requirements-txt --no-emit-project > requirements-audit.txt
+          uvx pip-audit -r requirements-audit.txt

--- a/uv.lock
+++ b/uv.lock
@@ -262,14 +262,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Substantially raises `cultivar`'s CI bar. Existing CI only ran pytest. This PR adds the missing quality gates:

1. **Lint** — a `lint` job running `ruff check` (ruff was already configured in `pyproject.toml` but never run in CI). Passes on the current tree.
2. **Dependency audit** — an `audit` job running `pip-audit` against the exported `uv.lock`, failing on known vulnerabilities. To make it green I bumped `click` 8.3.2 → 8.4.2 (clears PYSEC-2026-2132).
3. **Least-privilege permissions** — top-level `permissions: contents: read`.
4. **Dependabot** — `.github/dependabot.yml` for pip + github-actions.

## Verification (local)

- `uv run ruff check .` → passes ✅
- `uv run pytest` → **116 passed** ✅ (with the click bump; uv.lock diff is click-only)
- `pip-audit` after the click bump → **No known vulnerabilities found** ✅

## Follow-up

`ruff format --check` isn't gated yet — the tree isn't fully ruff-formatted, so enforcing it needs a `ruff format` pass (kept out to avoid a large reformat diff here). Same for the `ty` type checker (still preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)