### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Auto-requests review from the owners below on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @pinecone-io/dev-advocates


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so pull requests automatically request review from the appropriate owners.

Owners: `@pinecone-io/dev-advocates`

Part of an org-wide rollout to ensure every public repo has code owners configured.