### PR TITLE
fix: migrate to Sandbox.filesystem so remote runs work again

### DIFF
--- a/evals/remote/modal_runner.py
+++ b/evals/remote/modal_runner.py
@@ -107,15 +107,10 @@ def run_one_remote(
         # Drop the with-docs prompt prefix as a file in the sandbox so we can
         # pass it to entry.py without bloating argv (~100 KB cap, but argv is
         # noisy and harder to inspect than a file the entry script reads).
-        # NOTE: sb.filesystem.write_bytes raises TypeError on the Modal versions
-        # we hit in practice (signature drift). Using sb.open emits a
-        # PendingDeprecationWarning but actually works. Revisit when Modal
-        # stabilizes the filesystem API.
         docs_file_remote = ""
         if docs_context:
             docs_file_remote = "/workspace/.docs_context.txt"
-            with sb.open(docs_file_remote, "wb") as f:
-                f.write(docs_context.encode("utf-8"))
+            sb.filesystem.write_text(docs_context, docs_file_remote)
 
         # Run the eval via entry.py
         cmd_args = [
@@ -188,13 +183,11 @@ def run_one_remote(
                     continue
                 dest = workdir_out / rel
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                # sb.filesystem.copy_to_local raises TypeError on the Modal
-                # versions we use; sb.open emits a deprecation warning but
-                # actually pulls bytes back to local disk. Without this the
-                # workdir capture silently no-ops and code-gen runs autofail
-                # despite the agent having written the file.
-                with sb.open(abs_path, "rb") as src:
-                    dest.write_bytes(src.read())
+                # Keep the local write on our side instead of using
+                # copy_to_local, whose signature has drifted across Modal
+                # versions. If this capture breaks, code-gen runs autofail
+                # silently: the agent writes its file and nothing collects it.
+                dest.write_bytes(sb.filesystem.read_bytes(abs_path))
 
         # Run teardown inside sandbox
         if teardown:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
     "typer",
     "rich",
     "anthropic",
-    "modal",
+    # Floor, not a pin: the Sandbox.filesystem namespace this uses replaced an
+    # API Modal removed server-side, so an older client resolves fine and then
+    # fails at the first sandbox file write.
+    "modal>=1.5.4",
     "python-dotenv",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -307,7 +307,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic" },
-    { name = "modal" },
+    { name = "modal", specifier = ">=1.5.4" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.4.2"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -696,15 +696,14 @@ dependencies = [
     { name = "rich" },
     { name = "synchronicity" },
     { name = "toml" },
-    { name = "typer" },
     { name = "types-certifi" },
     { name = "types-toml" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/67/c84029cf5a0eaa366400d2cae3901c757a313349e7e1ccf4fc4644bf3cf8/modal-1.4.2.tar.gz", hash = "sha256:ab4e76a2c28fc0e0aebb616f11a2658051518d38cd241825af27fb34e2688b46", size = 699847, upload-time = "2026-04-16T20:28:00.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/0d/1a6e710ab64f0c7b7bec9472203dbf6c7c75556dd2d7632da98c96a4e0b0/modal-1.5.4.tar.gz", hash = "sha256:d611bb47fc07117f5d194f7f9a9c0aba4537573a136349bbe45c5694e64bca92", size = 863571, upload-time = "2026-08-12T21:54:12.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/65/fa87a72b7bf150dbf9949e503b8a45e278789201ac3691b8af1cd861a7d6/modal-1.4.2-py3-none-any.whl", hash = "sha256:6993874476dfd51057e36c778dbd7aae58811802515532447336eced00c81e28", size = 802775, upload-time = "2026-04-16T20:27:58.065Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/ca23b7b421e2c9738b710eb1d33eb25a88cba32dff864003a692a0e21f8d/modal-1.5.4-py3-none-any.whl", hash = "sha256:3e54e26037c445af42f9a9ef9862b66bdd2e0b1faeced5fcc7adf3e5f59e44ed", size = 979381, upload-time = "2026-08-12T21:54:10.378Z" },
 ]
 
 [[package]]
@@ -1267,14 +1266,14 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.12.2"
+version = "0.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What's broken

Every remote run fails right now. Modal turned off the old sandbox filesystem API on their side, so `cultivar run --remote` and `cultivar hello --remote` both die with:

```
ConflictError: The legacy Sandbox filesystem API is no longer supported.
```

The sandbox starts fine and the secret verifies fine. It fails the moment we try to put a file into the sandbox.

No recent change caused this. `sb.open()` has been in `modal_runner.py` since the first release. Modal deprecated it on 2026-03-09 and has now removed it, so the grace period just ran out.

## The fix

Two calls in `evals/remote/modal_runner.py`:

- writing the docs file into the sandbox: `sb.open(path, "wb")` -> `sb.filesystem.write_text(data, path)`
- reading result files back out: `sb.open(path, "rb")` -> `sb.filesystem.read_bytes(path)`

Careful with `write_text` — the data comes first, then the path.

Modal's migration guide points at `copy_to_local` for the read side. I used `read_bytes` instead. The comments I deleted said `copy_to_local` used to raise `TypeError` on some Modal versions, and we already do the local write ourselves, so this way there is less of Modal's code in the path.

## The dependency

`modal` was unpinned. That is why a working install turned into a broken one with no code change: a fresh install picks up whatever Modal shipped that day. It is now `modal>=1.5.4`, the version I tested against.

A floor, not a pin, so Dependabot can still move it.

One thing worth knowing: `uv.lock` had modal at 1.4.2, so a dev checkout was running an older client than a tool install. The lock moves to 1.5.4 as well.

## How I checked

- `cultivar hello --remote` passes, exit 0. It fails on `main`.
- Ran both new calls against a real sandbox and did a write-then-read round trip. Worth doing separately because `hello` runs the with-skill variant, which never sets `docs_context`, so it does not exercise the write path on its own.
- `ruff check .` clean, 116 tests pass.

## Note

This does not recover old runs. Anything that failed while the API was off has to be re-run.
