### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultivar"
-version = "0.4.0"
+version = "0.4.1"
 description = "Eval framework for testing whether agent skills improve behavior across coding CLIs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "cultivar"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Releases the Modal `Sandbox.filesystem` migration from #17.

0.4.0 cannot run remotely at all — Modal removed the legacy sandbox filesystem API server-side, so every `--remote` run fails at the first file write. This gets the fix onto PyPI.

Verified on the merged code: `cultivar hello --remote` passes, and both new call shapes were exercised against a live sandbox.