### PR TITLE
Support Claude 5-series models in the grader

### DIFF
--- a/docs/grader.md
+++ b/docs/grader.md
@@ -14,11 +14,21 @@ LLM-based grader that scores runner conversations against natural-language crite
 
 ## Model
 
-Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…` — any current Claude model works, including the "-5" generation (`claude-opus-5`, `claude-sonnet-5`) and Fable/Mythos 5, which think by default. The grader detects the model family and adjusts the request so the reply is still plain JSON text:
+Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…` — any current Claude model works, including the "-5" generation (`claude-opus-5`, `claude-sonnet-5`, optionally pinned to a dated snapshot like `claude-opus-5-20260315`) and Fable/Mythos 5, which think by default. The grader classifies the model from its id alone and adjusts the request so the reply is still plain JSON text:
 
 - Older models (`claude-haiku-4-5`, `claude-sonnet-4-6`, the 4.x Opus/Sonnet line) already default to no thinking — nothing changes for them.
-- Bare "-5" models (`claude-opus-5`, `claude-sonnet-5`) think by default, so the grader explicitly sends `thinking: {"type": "disabled"}`.
-- `claude-fable-5` / `claude-mythos-5` can't disable thinking at all — the grader omits the `thinking` param, runs at `effort: low` to keep thinking shallow, and gives the response more `max_tokens` headroom since thinking and the JSON reply share the same budget. Response parsing scans for the first text block instead of assuming it's `content[0]`.
+- Bare or dated "-5" models (`claude-opus-5`, `claude-sonnet-5`, `claude-opus-5-20260315`, …) think by default, so the grader explicitly sends `thinking: {"type": "disabled"}`.
+- `claude-fable-5` / `claude-mythos-5` (and their dated snapshots) can't disable thinking at all — the grader omits the `thinking` param, runs at `effort: low` to keep thinking shallow, and doubles `--max-tokens` since thinking and the JSON reply share the same budget.
+
+Response parsing scans past leading `thinking`/`redacted_thinking` blocks for the first text block instead of assuming it's `content[0]`, but still raises loudly on any other unexpected block type (e.g. `tool_use` — this call never passes tools, so seeing one means something is misconfigured).
+
+## Max tokens
+
+`--max-tokens` (default `4096`) caps each grader reply. Raise it if `evidence`/`reasoning` are getting truncated — check `grades.json` for a `reasoning` mentioning `_salvage_truncated_grade`'s header-only recovery — or if you're using a model whose thinking can't be disabled; those already get double whatever value you pass here.
+
+## Grader call failures
+
+If a single conversation's grading call raises (e.g. a thinking-only model exhausts `--max-tokens` before producing any text), it no longer aborts the whole run. `_grade_conversation_safely` converts the exception into a normal FAIL grade with a `cause`/`fix` suggestion naming the error, prints a warning, and the rest of the batch continues — only that one entry needs a re-grade.
 
 ## Prompt anatomy
 

--- a/docs/grader.md
+++ b/docs/grader.md
@@ -14,7 +14,11 @@ LLM-based grader that scores runner conversations against natural-language crite
 
 ## Model
 
-Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…`.
+Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…` — any current Claude model works, including the "-5" generation (`claude-opus-5`, `claude-sonnet-5`) and Fable/Mythos 5, which think by default. The grader detects the model family and adjusts the request so the reply is still plain JSON text:
+
+- Older models (`claude-haiku-4-5`, `claude-sonnet-4-6`, the 4.x Opus/Sonnet line) already default to no thinking — nothing changes for them.
+- Bare "-5" models (`claude-opus-5`, `claude-sonnet-5`) think by default, so the grader explicitly sends `thinking: {"type": "disabled"}`.
+- `claude-fable-5` / `claude-mythos-5` can't disable thinking at all — the grader omits the `thinking` param, runs at `effort: low` to keep thinking shallow, and gives the response more `max_tokens` headroom since thinking and the JSON reply share the same budget. Response parsing scans for the first text block instead of assuming it's `content[0]`.
 
 ## Prompt anatomy
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -90,7 +90,9 @@ Two pre-API short-circuits to avoid hallucinated grades:
 - Empty/no-signal conversation → autofail before the call.
 - `category: code-gen` with an empty workdir → autofail before the call.
 
-If the model truncates its JSON mid-evidence, `_salvage_truncated_grade()` regex-extracts the verdict so a real PASS doesn't become a fake FAIL. `GRADER_MAX_TOKENS = 4096`.
+If the model truncates its JSON mid-evidence, `_salvage_truncated_grade()` regex-extracts the verdict so a real PASS doesn't become a fake FAIL. Default reply budget is `--max-tokens 4096` (doubled automatically for models that can't disable thinking, e.g. `claude-fable-5`); raise it if truncation recurs.
+
+If a single grading call raises, `_grade_conversation_safely()` turns it into a FAIL grade instead of aborting the rest of the run.
 
 Full prompt anatomy + calibration mechanics: [docs/grader.md](../docs/grader.md).
 

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -9,7 +9,7 @@ from typing import Any
 import typer
 import yaml
 from anthropic import Anthropic
-from anthropic.types import TextBlock
+from anthropic.types import RedactedThinkingBlock, TextBlock, ThinkingBlock
 
 from evals.framework.reporting import (
     console,
@@ -537,15 +537,25 @@ def grade_one(
 
     # The SDK's content blocks are a discriminated union; only TextBlock has
     # .text. Grader prompts don't use tools, but models that think by default
-    # (and can't be told not to, e.g. Fable 5 / Mythos 5) prepend one or more
-    # thinking blocks — so find the first TextBlock rather than assuming
-    # content[0] is it.
-    text_block = next((b for b in response.content if isinstance(b, TextBlock)), None)
+    # (and can't be told not to, e.g. Fable 5 / Mythos 5) legitimately prepend
+    # one or more thinking blocks — tolerate those specifically instead of
+    # assuming content[0] is the reply, but still fail loudly on anything else
+    # (e.g. a tool_use block, which would mean something is misconfigured).
+    text_block = None
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            text_block = block
+            break
+        if not isinstance(block, (ThinkingBlock, RedactedThinkingBlock)):
+            raise RuntimeError(
+                f"Grader response contained an unexpected {type(block).__name__} block. "
+                "Did someone enable tool use on the grader call?"
+            )
     if text_block is None:
-        block_types = [type(b).__name__ for b in response.content]
         raise RuntimeError(
-            f"Grader response contained no TextBlock (got: {block_types}). "
-            "Did someone enable tool use on the grader call?"
+            "Grader response contained only thinking blocks, no text reply. The model "
+            "likely spent its entire max_tokens budget thinking before producing any "
+            "output — try raising --max-tokens or lowering the grading model's effort."
         )
     text = text_block.text.strip()
     if text.startswith("```"):

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -48,7 +48,7 @@ GRADER_MAX_TOKENS = 4096
 
 # Some models generate a thinking block or two before the JSON reply's text
 # block, which shares this budget -- give those calls extra headroom so the
-# reply itself doesn't get truncated. See _thinking_kwargs below.
+# reply itself doesn't get truncated. See _grader_request_kwargs below.
 GRADER_MAX_TOKENS_WITH_THINKING = 8192
 
 # Claude Fable 5 / Mythos 5 think on every request and reject an explicit
@@ -63,23 +63,29 @@ _ALWAYS_THINKS = re.compile(r"^claude-(fable|mythos)-\d")
 _THINKS_BY_DEFAULT = re.compile(r"^claude-[a-z]+-\d+$")
 
 
-def _thinking_kwargs(model: str) -> dict:
-    """Extra `messages.create` kwargs that keep a grader call thinking-free.
+def _grader_request_kwargs(model: str) -> dict:
+    """All extra `messages.create` kwargs for a grader call, keyed by model alone.
 
-    The grader's job is a plain pass/fail classification -- it never needs
-    extended thinking, and `grade_one` assumes the reply is a JSON text
-    block. Older models (haiku-4-5, sonnet-4-6, the 4.x Opus/Sonnet line)
-    already run with thinking off by default, so nothing needs to change for
-    them. The "-5" generation thinks by default, so explicitly turn it back
-    off. Fable 5 / Mythos 5 can't turn thinking off at all -- leave `thinking`
-    unset for those and rely on `grade_one` scanning the response for the
-    text block instead of assuming it's first.
+    This is the single place that decides how a thinking-by-default Claude
+    model is handled -- `max_tokens` and the `thinking`/`output_config` kwargs
+    used to be decided in two separate places (this classification, and a
+    second one at the call site), which could silently desync if either was
+    edited without updating the other. The grader's job is a plain pass/fail
+    classification -- it never needs extended thinking, and `grade_one`
+    assumes the reply is a JSON text block. Older models (haiku-4-5,
+    sonnet-4-6, the 4.x Opus/Sonnet line) already run with thinking off by
+    default, so they get no extra kwargs. The "-5" generation thinks by
+    default, so explicitly turn it back off. Fable 5 / Mythos 5 can't turn
+    thinking off at all -- omit `thinking` for those, keep it shallow with a
+    low effort, and double the token budget since thinking and the reply
+    share it (see `grade_one`'s response parsing, which scans past leading
+    thinking blocks instead of assuming the reply is `content[0]`).
     """
     if _ALWAYS_THINKS.match(model):
-        return {}
+        return {"max_tokens": GRADER_MAX_TOKENS_WITH_THINKING, "output_config": {"effort": "low"}}
     if _THINKS_BY_DEFAULT.match(model):
-        return {"thinking": {"type": "disabled"}}
-    return {}
+        return {"max_tokens": GRADER_MAX_TOKENS, "thinking": {"type": "disabled"}}
+    return {"max_tokens": GRADER_MAX_TOKENS}
 
 
 _AGENT_SIGNALS = (
@@ -517,16 +523,10 @@ def grade_one(
         task, conv_str, examples_block, skill_content, verify_output, workdir_content, refs_content
     )
 
-    thinking_kwargs = _thinking_kwargs(model)
-    always_thinks = bool(_ALWAYS_THINKS.match(model))
-    if always_thinks:
-        thinking_kwargs["output_config"] = {"effort": "low"}
-
     response = client.messages.create(
         model=model,
-        max_tokens=GRADER_MAX_TOKENS_WITH_THINKING if always_thinks else GRADER_MAX_TOKENS,
         messages=[{"role": "user", "content": prompt}],
-        **thinking_kwargs,
+        **_grader_request_kwargs(model),
     )
 
     # The SDK's content blocks are a discriminated union; only TextBlock has

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import typer
 import yaml
-from anthropic import Anthropic
+from anthropic import Anthropic, AuthenticationError, PermissionDeniedError
 from anthropic.types import RedactedThinkingBlock, TextBlock, ThinkingBlock
 
 from evals.framework.reporting import (
@@ -597,9 +597,18 @@ def _grade_conversation_safely(
     ways to raise were essentially unreachable), but a thinking-by-default
     model can genuinely raise if it exhausts its budget on thinking before
     producing any text, so the call is now guarded.
+
+    Auth/permission errors are deliberately excluded from that guard: a bad
+    or revoked API key fails the same way on every remaining conversation, so
+    swallowing it here would grind through the whole batch producing a wall
+    of identical misleading FAIL grades instead of surfacing the real
+    problem once, immediately -- the way the CLI already did before this
+    wrapper existed.
     """
     try:
         return grade_one(client, model, task, conversation, examples_block, skill_content, workdir_content, max_tokens)
+    except (AuthenticationError, PermissionDeniedError):
+        raise
     except Exception as e:
         console.print(f"[red]Grader call failed for {label}: {e}[/red]")
         return {

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -46,11 +46,6 @@ DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
 GRADER_MAX_TOKENS = 4096
 
-# Some models generate a thinking block or two before the JSON reply's text
-# block, which shares this budget -- give those calls extra headroom so the
-# reply itself doesn't get truncated. See _grader_request_kwargs below.
-GRADER_MAX_TOKENS_WITH_THINKING = 8192
-
 # Claude Fable 5 / Mythos 5 think on every request and reject an explicit
 # `thinking: {"type": "disabled"}` at any effort level -- the grader must not
 # send a `thinking` param to these at all. The optional `-YYYYMMDD` group
@@ -69,7 +64,7 @@ _ALWAYS_THINKS = re.compile(r"^claude-(fable|mythos)-\d+(-\d{8})?$")
 _THINKS_BY_DEFAULT = re.compile(r"^claude-(opus|sonnet|haiku)-\d+(-\d{8})?$")
 
 
-def _grader_request_kwargs(model: str) -> dict:
+def _grader_request_kwargs(model: str, base_max_tokens: int = GRADER_MAX_TOKENS) -> dict:
     """All extra `messages.create` kwargs for a grader call, keyed by model alone.
 
     This is the single place that decides how a thinking-by-default Claude
@@ -80,18 +75,19 @@ def _grader_request_kwargs(model: str) -> dict:
     classification -- it never needs extended thinking, and `grade_one`
     assumes the reply is a JSON text block. Older models (haiku-4-5,
     sonnet-4-6, the 4.x Opus/Sonnet line) already run with thinking off by
-    default, so they get no extra kwargs. The "-5" generation thinks by
-    default, so explicitly turn it back off. Fable 5 / Mythos 5 can't turn
-    thinking off at all -- omit `thinking` for those, keep it shallow with a
-    low effort, and double the token budget since thinking and the reply
-    share it (see `grade_one`'s response parsing, which scans past leading
-    thinking blocks instead of assuming the reply is `content[0]`).
+    default, so they get `base_max_tokens` unchanged. The "-5" generation
+    thinks by default, so explicitly turn it back off. Fable 5 / Mythos 5
+    can't turn thinking off at all -- omit `thinking` for those, keep it
+    shallow with a low effort, and double `base_max_tokens` since thinking
+    and the reply share it (see `grade_one`'s response parsing, which scans
+    past leading thinking blocks instead of assuming the reply is
+    `content[0]`).
     """
     if _ALWAYS_THINKS.match(model):
-        return {"max_tokens": GRADER_MAX_TOKENS_WITH_THINKING, "output_config": {"effort": "low"}}
+        return {"max_tokens": base_max_tokens * 2, "output_config": {"effort": "low"}}
     if _THINKS_BY_DEFAULT.match(model):
-        return {"max_tokens": GRADER_MAX_TOKENS, "thinking": {"type": "disabled"}}
-    return {"max_tokens": GRADER_MAX_TOKENS}
+        return {"max_tokens": base_max_tokens, "thinking": {"type": "disabled"}}
+    return {"max_tokens": base_max_tokens}
 
 
 _AGENT_SIGNALS = (
@@ -468,6 +464,7 @@ def grade_one(
     examples_block: str,
     skill_content: str = "",
     workdir_content: str = "",
+    max_tokens: int = GRADER_MAX_TOKENS,
 ) -> dict[str, Any]:
     conv_str = conversation.get("conversation_md", "")
 
@@ -532,7 +529,7 @@ def grade_one(
     response = client.messages.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
-        **_grader_request_kwargs(model),
+        **_grader_request_kwargs(model, max_tokens),
     )
 
     # The SDK's content blocks are a discriminated union; only TextBlock has
@@ -589,6 +586,7 @@ def _grade_conversation_safely(
     skill_content: str,
     workdir_content: str,
     label: str,
+    max_tokens: int = GRADER_MAX_TOKENS,
 ) -> dict[str, Any]:
     """Call grade_one, turning any exception into a FAIL grade instead of propagating it.
 
@@ -601,7 +599,7 @@ def _grade_conversation_safely(
     producing any text, so the call is now guarded.
     """
     try:
-        return grade_one(client, model, task, conversation, examples_block, skill_content, workdir_content)
+        return grade_one(client, model, task, conversation, examples_block, skill_content, workdir_content, max_tokens)
     except Exception as e:
         console.print(f"[red]Grader call failed for {label}: {e}[/red]")
         return {
@@ -639,7 +637,7 @@ def _salvage_truncated_grade(text: str) -> dict:
             "reasoning": (
                 "Grader response exceeded max_tokens or was malformed; recovered "
                 "the pass/fail verdict from the start of the JSON. Evidence and "
-                "reasoning fields lost — bump GRADER_MAX_TOKENS or tighten the "
+                "reasoning fields lost — pass a higher --max-tokens or tighten the "
                 "criteria's evidence cap if this recurs."
             ),
         }
@@ -683,6 +681,14 @@ def main(
         help="Skill name for loading SKILL.md + calibration examples. Auto-detected from <results_dir>/tasks.json if omitted.",
     ),
     model: str = typer.Option(DEFAULT_MODEL, help=f"Anthropic model id for grading. Default: {DEFAULT_MODEL}."),
+    max_tokens: int = typer.Option(
+        GRADER_MAX_TOKENS,
+        "--max-tokens",
+        help=(
+            "Max tokens for each grader reply. Doubled automatically for models that "
+            f"can't disable thinking (e.g. claude-fable-5). Default: {GRADER_MAX_TOKENS}."
+        ),
+    ),
     report: bool = typer.Option(
         True, help="Print the report after grading. Use --no-report to only write grades.json."
     ),
@@ -714,6 +720,7 @@ def main(
       cultivar grade latest --model claude-sonnet-4-6        # use a stronger grader
       cultivar grade latest --no-report                      # write grades.json, skip the report
       cultivar grade latest --fail-under 80                  # exit 1 if with-skill pass rate < 80%
+      cultivar grade latest --max-tokens 8192                 # give the grader more room per reply
 
     See docs/grader.md for prompt structure and calibration tips.
     """
@@ -829,6 +836,7 @@ def main(
                     skill_content,
                     workdir_content,
                     label=f"{task_id} / {runner_name}/{variant}",
+                    max_tokens=max_tokens,
                 )
 
             # Extract run stats from the JSON output

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -564,6 +564,45 @@ def grade_one(
     return grade
 
 
+def _grade_conversation_safely(
+    client: Anthropic,
+    model: str,
+    task: dict,
+    conversation: dict,
+    examples_block: str,
+    skill_content: str,
+    workdir_content: str,
+    label: str,
+) -> dict[str, Any]:
+    """Call grade_one, turning any exception into a FAIL grade instead of propagating it.
+
+    main()'s loop grades every conversation in a results dir before writing
+    grades.json once at the end -- an uncaught exception from grade_one on
+    one file would abort the whole run and discard every grade already
+    computed for it. This used to be a low-risk assumption (grade_one's few
+    ways to raise were essentially unreachable), but a thinking-by-default
+    model can genuinely raise if it exhausts its budget on thinking before
+    producing any text, so the call is now guarded.
+    """
+    try:
+        return grade_one(client, model, task, conversation, examples_block, skill_content, workdir_content)
+    except Exception as e:
+        console.print(f"[red]Grader call failed for {label}: {e}[/red]")
+        return {
+            "pass": False,
+            "proposed_command": "",
+            "evidence": "",
+            "reasoning": f"Grader call raised {type(e).__name__}: {e}",
+            "suggestions": [
+                {
+                    "cause": f"grade_one() raised {type(e).__name__} instead of returning a grade.",
+                    "fix": "Re-run `cultivar grade` for this results dir once the cause is fixed — "
+                    "other conversations' grades in this run were not affected.",
+                }
+            ],
+        }
+
+
 def _salvage_truncated_grade(text: str) -> dict:
     """Best-effort field extraction when the grader's JSON is malformed/truncated.
 
@@ -765,7 +804,16 @@ def main(
                 examples_block = load_examples(skill, task_id=task_id)
                 workdir = conv_file.parent / f"{conv_file.stem}.workdir"
                 workdir_content = load_workdir_files(workdir)
-                grade = grade_one(client, model, task, conversation, examples_block, skill_content, workdir_content)
+                grade = _grade_conversation_safely(
+                    client,
+                    model,
+                    task,
+                    conversation,
+                    examples_block,
+                    skill_content,
+                    workdir_content,
+                    label=f"{task_id} / {runner_name}/{variant}",
+                )
 
             # Extract run stats from the JSON output
             usage = conversation.get("usage") or {}

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -53,14 +53,20 @@ GRADER_MAX_TOKENS_WITH_THINKING = 8192
 
 # Claude Fable 5 / Mythos 5 think on every request and reject an explicit
 # `thinking: {"type": "disabled"}` at any effort level -- the grader must not
-# send a `thinking` param to these at all.
-_ALWAYS_THINKS = re.compile(r"^claude-(fable|mythos)-\d")
+# send a `thinking` param to these at all. The optional `-YYYYMMDD` group
+# matches a pinned dated snapshot (e.g. "claude-fable-5-20260315") the same
+# way as the bare alias.
+_ALWAYS_THINKS = re.compile(r"^claude-(fable|mythos)-\d+(-\d{8})?$")
 
-# The "-5" model generation (Opus 5, Sonnet 5, ...) thinks by default but can
-# be told not to. Matches bare `claude-<family>-<generation>` ids and not the
-# older dotted/dated ones (`claude-haiku-4-5`, `claude-opus-4-6`, ...), which
-# already default to no thinking and need no extra kwargs here.
-_THINKS_BY_DEFAULT = re.compile(r"^claude-[a-z]+-\d+$")
+# The "-5" model generation (Opus 5, Sonnet 5, Haiku 5, ...) thinks by default
+# but can be told not to. The family name is an explicit allowlist rather
+# than a loose `[a-z]+`, which would also match model ids from unrelated
+# families with the same shallow `family-digit` shape (e.g. "claude-instant-1")
+# that never had a thinking concept at all. Matches a bare generation number
+# or one pinned to a `-YYYYMMDD` dated snapshot, and not the dotted/multi-part
+# ids (`claude-haiku-4-5`, `claude-opus-4-6`, ...), which already default to
+# no thinking and need no extra kwargs here.
+_THINKS_BY_DEFAULT = re.compile(r"^claude-(opus|sonnet|haiku)-\d+(-\d{8})?$")
 
 
 def _grader_request_kwargs(model: str) -> dict:

--- a/evals/framework/grader.py
+++ b/evals/framework/grader.py
@@ -46,6 +46,41 @@ DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 
 GRADER_MAX_TOKENS = 4096
 
+# Some models generate a thinking block or two before the JSON reply's text
+# block, which shares this budget -- give those calls extra headroom so the
+# reply itself doesn't get truncated. See _thinking_kwargs below.
+GRADER_MAX_TOKENS_WITH_THINKING = 8192
+
+# Claude Fable 5 / Mythos 5 think on every request and reject an explicit
+# `thinking: {"type": "disabled"}` at any effort level -- the grader must not
+# send a `thinking` param to these at all.
+_ALWAYS_THINKS = re.compile(r"^claude-(fable|mythos)-\d")
+
+# The "-5" model generation (Opus 5, Sonnet 5, ...) thinks by default but can
+# be told not to. Matches bare `claude-<family>-<generation>` ids and not the
+# older dotted/dated ones (`claude-haiku-4-5`, `claude-opus-4-6`, ...), which
+# already default to no thinking and need no extra kwargs here.
+_THINKS_BY_DEFAULT = re.compile(r"^claude-[a-z]+-\d+$")
+
+
+def _thinking_kwargs(model: str) -> dict:
+    """Extra `messages.create` kwargs that keep a grader call thinking-free.
+
+    The grader's job is a plain pass/fail classification -- it never needs
+    extended thinking, and `grade_one` assumes the reply is a JSON text
+    block. Older models (haiku-4-5, sonnet-4-6, the 4.x Opus/Sonnet line)
+    already run with thinking off by default, so nothing needs to change for
+    them. The "-5" generation thinks by default, so explicitly turn it back
+    off. Fable 5 / Mythos 5 can't turn thinking off at all -- leave `thinking`
+    unset for those and rely on `grade_one` scanning the response for the
+    text block instead of assuming it's first.
+    """
+    if _ALWAYS_THINKS.match(model):
+        return {}
+    if _THINKS_BY_DEFAULT.match(model):
+        return {"thinking": {"type": "disabled"}}
+    return {}
+
 
 _AGENT_SIGNALS = (
     "**Assistant:**",
@@ -482,24 +517,31 @@ def grade_one(
         task, conv_str, examples_block, skill_content, verify_output, workdir_content, refs_content
     )
 
+    thinking_kwargs = _thinking_kwargs(model)
+    always_thinks = bool(_ALWAYS_THINKS.match(model))
+    if always_thinks:
+        thinking_kwargs["output_config"] = {"effort": "low"}
+
     response = client.messages.create(
         model=model,
-        max_tokens=GRADER_MAX_TOKENS,
+        max_tokens=GRADER_MAX_TOKENS_WITH_THINKING if always_thinks else GRADER_MAX_TOKENS,
         messages=[{"role": "user", "content": prompt}],
+        **thinking_kwargs,
     )
 
     # The SDK's content blocks are a discriminated union; only TextBlock has
-    # .text. Grader prompts don't use tools or thinking, so the first block is
-    # always TextBlock at runtime — narrow explicitly so the type checker is
-    # happy and any future drift (e.g. enabling thinking) fails loudly instead
-    # of silently.
-    first_block = response.content[0]
-    if not isinstance(first_block, TextBlock):
+    # .text. Grader prompts don't use tools, but models that think by default
+    # (and can't be told not to, e.g. Fable 5 / Mythos 5) prepend one or more
+    # thinking blocks — so find the first TextBlock rather than assuming
+    # content[0] is it.
+    text_block = next((b for b in response.content if isinstance(b, TextBlock)), None)
+    if text_block is None:
+        block_types = [type(b).__name__ for b in response.content]
         raise RuntimeError(
-            f"Grader response first block was {type(first_block).__name__}, expected TextBlock. "
-            "Did someone enable thinking or tool use on the grader call?"
+            f"Grader response contained no TextBlock (got: {block_types}). "
+            "Did someone enable tool use on the grader call?"
         )
-    text = first_block.text.strip()
+    text = text_block.text.strip()
     if text.startswith("```"):
         lines = text.split("\n")
         # Remove opening fence (```json, ```, etc.)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1017,6 +1017,29 @@ class TestEmptyTraceAutofail:
         assert self.has(md) is True
 
 
+def _fake_anthropic_client(content):
+    """A minimal stand-in for anthropic.Anthropic() that records the kwargs
+    passed to messages.create and returns a canned response."""
+
+    class FakeResponse:
+        def __init__(self, content):
+            self.content = content
+
+    class FakeMessages:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return FakeResponse(content)
+
+    class FakeClient:
+        def __init__(self):
+            self.messages = FakeMessages()
+
+    return FakeClient()
+
+
 class TestThinkingKwargs:
     """_thinking_kwargs: model-aware handling of Claude's thinking-by-default models."""
 
@@ -1059,23 +1082,7 @@ class TestGradeOneThinkingModels:
             pytest.skip("anthropic SDK not installed")
 
     def _fake_client(self, content):
-        class FakeResponse:
-            def __init__(self, content):
-                self.content = content
-
-        class FakeMessages:
-            def __init__(self):
-                self.calls = []
-
-            def create(self, **kwargs):
-                self.calls.append(kwargs)
-                return FakeResponse(content)
-
-        class FakeClient:
-            def __init__(self):
-                self.messages = FakeMessages()
-
-        return FakeClient()
+        return _fake_anthropic_client(content)
 
     def _task_and_conversation(self):
         task = {"ground_truth": {"criteria": "test"}}
@@ -1119,6 +1126,50 @@ class TestGradeOneThinkingModels:
         task, conversation = self._task_and_conversation()
         with pytest.raises(RuntimeError, match="no TextBlock"):
             self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
+
+
+class TestGradeConversationSafely:
+    """_grade_conversation_safely: a grader crash must not blow up the whole batch."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        try:
+            from anthropic.types import ThinkingBlock
+
+            from evals.framework.grader import _grade_conversation_safely
+
+            self.safe_grade = _grade_conversation_safely
+            self.ThinkingBlock = ThinkingBlock
+        except ImportError:
+            pytest.skip("anthropic SDK not installed")
+
+    def test_grade_one_exception_becomes_a_fail_grade(self):
+        """A thinking-only response with no text (see TestGradeOneThinkingModels
+        above) makes grade_one raise -- the wrapper must catch it and return a
+        FAIL grade instead of letting it propagate out of main()'s loop."""
+        content = [self.ThinkingBlock(type="thinking", thinking="", signature="sig")]
+        client = _fake_anthropic_client(content)
+        task = {"ground_truth": {"criteria": "test"}}
+        conversation = {"conversation_md": "**Assistant:** did the thing"}
+
+        grade = self.safe_grade(
+            client, "claude-fable-5", task, conversation, "", "", "", label="my-task / claude/with-skill"
+        )
+
+        assert grade["pass"] is False
+        assert "RuntimeError" in grade["reasoning"]
+        assert grade["suggestions"]
+
+    def test_successful_grade_passes_through_unchanged(self):
+        from anthropic.types import TextBlock
+
+        client = _fake_anthropic_client([TextBlock(type="text", text='{"pass": true}')])
+        task = {"ground_truth": {"criteria": "test"}}
+        conversation = {"conversation_md": "**Assistant:** did the thing"}
+
+        grade = self.safe_grade(client, "claude-haiku-4-5-20251001", task, conversation, "", "", "", label="task/x")
+
+        assert grade["pass"] is True
 
 
 class TestCodeGenEmptyWorkdirAutofail:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1089,13 +1089,15 @@ class TestGradeOneThinkingModels:
     @pytest.fixture(autouse=True)
     def _import(self):
         try:
-            from anthropic.types import TextBlock, ThinkingBlock
+            from anthropic.types import RedactedThinkingBlock, TextBlock, ThinkingBlock, ToolUseBlock
 
             from evals.framework.grader import grade_one
 
             self.grade_one = grade_one
             self.TextBlock = TextBlock
             self.ThinkingBlock = ThinkingBlock
+            self.RedactedThinkingBlock = RedactedThinkingBlock
+            self.ToolUseBlock = ToolUseBlock
         except ImportError:
             pytest.skip("anthropic SDK not installed")
 
@@ -1142,8 +1144,31 @@ class TestGradeOneThinkingModels:
         content = [self.ThinkingBlock(type="thinking", thinking="", signature="sig")]
         client = self._fake_client(content)
         task, conversation = self._task_and_conversation()
-        with pytest.raises(RuntimeError, match="no TextBlock"):
+        with pytest.raises(RuntimeError, match="only thinking blocks"):
             self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
+
+    def test_redacted_thinking_block_is_also_tolerated(self):
+        content = [
+            self.RedactedThinkingBlock(type="redacted_thinking", data="encrypted"),
+            self.TextBlock(type="text", text='{"pass": true}'),
+        ]
+        client = self._fake_client(content)
+        task, conversation = self._task_and_conversation()
+        grade = self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
+        assert grade["pass"] is True
+
+    def test_tool_use_block_before_text_still_raises_loudly(self):
+        """A tool_use block means something is misconfigured (the grader call
+        never passes tools=) -- unlike thinking blocks, it must not be
+        silently skipped over on the way to the trailing text block."""
+        content = [
+            self.ToolUseBlock(type="tool_use", id="toolu_1", name="some_tool", input={}),
+            self.TextBlock(type="text", text='{"pass": true}'),
+        ]
+        client = self._fake_client(content)
+        task, conversation = self._task_and_conversation()
+        with pytest.raises(RuntimeError, match="unexpected ToolUseBlock"):
+            self.grade_one(client, "claude-haiku-4-5-20251001", task, conversation, examples_block="")
 
 
 class TestGradeConversationSafely:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1215,6 +1215,31 @@ class TestGradeConversationSafely:
         assert "RuntimeError" in grade["reasoning"]
         assert grade["suggestions"]
 
+    def test_auth_error_is_not_swallowed(self):
+        """A bad/revoked API key fails identically on every remaining
+        conversation -- it must still crash the run immediately instead of
+        producing a wall of misleading per-conversation FAIL grades."""
+        import httpx
+        from anthropic import AuthenticationError
+
+        class FailingMessages:
+            def create(self, **kwargs):
+                request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+                response = httpx.Response(401, request=request)
+                raise AuthenticationError("invalid x-api-key", response=response, body=None)
+
+        class FailingClient:
+            def __init__(self):
+                self.messages = FailingMessages()
+
+        task = {"ground_truth": {"criteria": "test"}}
+        conversation = {"conversation_md": "**Assistant:** did the thing"}
+
+        with pytest.raises(AuthenticationError):
+            self.safe_grade(
+                FailingClient(), "claude-haiku-4-5-20251001", task, conversation, "", "", "", label="task/x"
+            )
+
     def test_successful_grade_passes_through_unchanged(self):
         from anthropic.types import TextBlock
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1082,6 +1082,11 @@ class TestGraderRequestKwargs:
         thinking concept -- it must fall through to plain max_tokens."""
         assert self.kwargs("claude-instant-1") == {"max_tokens": 4096}
 
+    def test_custom_base_max_tokens_is_respected_and_doubled_where_needed(self):
+        assert self.kwargs("claude-haiku-4-5-20251001", 2000) == {"max_tokens": 2000}
+        assert self.kwargs("claude-opus-5", 2000) == {"max_tokens": 2000, "thinking": {"type": "disabled"}}
+        assert self.kwargs("claude-fable-5", 2000) == {"max_tokens": 4000, "output_config": {"effort": "low"}}
+
 
 class TestGradeOneThinkingModels:
     """grade_one: request shape and response parsing across model families."""
@@ -1157,6 +1162,13 @@ class TestGradeOneThinkingModels:
         grade = self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
         assert grade["pass"] is True
 
+    def test_custom_max_tokens_is_threaded_through(self):
+        client = self._fake_client([self.TextBlock(type="text", text='{"pass": true}')])
+        task, conversation = self._task_and_conversation()
+        self.grade_one(client, "claude-opus-5", task, conversation, examples_block="", max_tokens=1024)
+        call = client.messages.calls[0]
+        assert call["max_tokens"] == 1024
+
     def test_tool_use_block_before_text_still_raises_loudly(self):
         """A tool_use block means something is misconfigured (the grader call
         never passes tools=) -- unlike thinking blocks, it must not be
@@ -1213,6 +1225,19 @@ class TestGradeConversationSafely:
         grade = self.safe_grade(client, "claude-haiku-4-5-20251001", task, conversation, "", "", "", label="task/x")
 
         assert grade["pass"] is True
+
+
+class TestGradeCliMaxTokensFlag:
+    """`cultivar grade --max-tokens` is wired up on the CLI, not just grade_one()."""
+
+    def test_max_tokens_flag_is_registered(self):
+        from typer.testing import CliRunner
+
+        from evals.cli import app
+
+        result = CliRunner().invoke(app, ["grade", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--max-tokens" in result.output
 
 
 class TestCodeGenEmptyWorkdirAutofail:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1040,29 +1040,34 @@ def _fake_anthropic_client(content):
     return FakeClient()
 
 
-class TestThinkingKwargs:
-    """_thinking_kwargs: model-aware handling of Claude's thinking-by-default models."""
+class TestGraderRequestKwargs:
+    """_grader_request_kwargs: model-aware handling of Claude's thinking-by-default models.
+
+    This is the single source of truth for both the thinking-related kwargs
+    and max_tokens -- grade_one no longer re-derives either separately.
+    """
 
     @pytest.fixture(autouse=True)
     def _import(self):
         try:
-            from evals.framework.grader import _thinking_kwargs
+            from evals.framework.grader import _grader_request_kwargs
 
-            self.kwargs = _thinking_kwargs
+            self.kwargs = _grader_request_kwargs
         except ImportError:
             pytest.skip("anthropic SDK not installed")
 
-    def test_older_dated_model_gets_no_thinking_kwargs(self):
-        assert self.kwargs("claude-haiku-4-5-20251001") == {}
-        assert self.kwargs("claude-opus-4-6") == {}
+    def test_older_dated_model_gets_base_max_tokens_only(self):
+        assert self.kwargs("claude-haiku-4-5-20251001") == {"max_tokens": 4096}
+        assert self.kwargs("claude-opus-4-6") == {"max_tokens": 4096}
 
     def test_bare_five_series_model_disables_thinking(self):
-        assert self.kwargs("claude-opus-5") == {"thinking": {"type": "disabled"}}
-        assert self.kwargs("claude-sonnet-5") == {"thinking": {"type": "disabled"}}
+        assert self.kwargs("claude-opus-5") == {"max_tokens": 4096, "thinking": {"type": "disabled"}}
+        assert self.kwargs("claude-sonnet-5") == {"max_tokens": 4096, "thinking": {"type": "disabled"}}
 
-    def test_fable_and_mythos_get_no_thinking_kwargs(self):
-        assert self.kwargs("claude-fable-5") == {}
-        assert self.kwargs("claude-mythos-5") == {}
+    def test_fable_and_mythos_get_low_effort_and_doubled_budget(self):
+        expected = {"max_tokens": 8192, "output_config": {"effort": "low"}}
+        assert self.kwargs("claude-fable-5") == expected
+        assert self.kwargs("claude-mythos-5") == expected
 
 
 class TestGradeOneThinkingModels:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1017,6 +1017,110 @@ class TestEmptyTraceAutofail:
         assert self.has(md) is True
 
 
+class TestThinkingKwargs:
+    """_thinking_kwargs: model-aware handling of Claude's thinking-by-default models."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        try:
+            from evals.framework.grader import _thinking_kwargs
+
+            self.kwargs = _thinking_kwargs
+        except ImportError:
+            pytest.skip("anthropic SDK not installed")
+
+    def test_older_dated_model_gets_no_thinking_kwargs(self):
+        assert self.kwargs("claude-haiku-4-5-20251001") == {}
+        assert self.kwargs("claude-opus-4-6") == {}
+
+    def test_bare_five_series_model_disables_thinking(self):
+        assert self.kwargs("claude-opus-5") == {"thinking": {"type": "disabled"}}
+        assert self.kwargs("claude-sonnet-5") == {"thinking": {"type": "disabled"}}
+
+    def test_fable_and_mythos_get_no_thinking_kwargs(self):
+        assert self.kwargs("claude-fable-5") == {}
+        assert self.kwargs("claude-mythos-5") == {}
+
+
+class TestGradeOneThinkingModels:
+    """grade_one: request shape and response parsing across model families."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        try:
+            from anthropic.types import TextBlock, ThinkingBlock
+
+            from evals.framework.grader import grade_one
+
+            self.grade_one = grade_one
+            self.TextBlock = TextBlock
+            self.ThinkingBlock = ThinkingBlock
+        except ImportError:
+            pytest.skip("anthropic SDK not installed")
+
+    def _fake_client(self, content):
+        class FakeResponse:
+            def __init__(self, content):
+                self.content = content
+
+        class FakeMessages:
+            def __init__(self):
+                self.calls = []
+
+            def create(self, **kwargs):
+                self.calls.append(kwargs)
+                return FakeResponse(content)
+
+        class FakeClient:
+            def __init__(self):
+                self.messages = FakeMessages()
+
+        return FakeClient()
+
+    def _task_and_conversation(self):
+        task = {"ground_truth": {"criteria": "test"}}
+        conversation = {"conversation_md": "**Assistant:** did the thing"}
+        return task, conversation
+
+    def test_five_series_model_disables_thinking(self):
+        client = self._fake_client([self.TextBlock(type="text", text='{"pass": true}')])
+        task, conversation = self._task_and_conversation()
+        self.grade_one(client, "claude-opus-5", task, conversation, examples_block="")
+        call = client.messages.calls[0]
+        assert call["thinking"] == {"type": "disabled"}
+        assert call["max_tokens"] == 4096
+
+    def test_always_thinking_model_skips_thinking_param_and_parses_past_it(self):
+        content = [
+            self.ThinkingBlock(type="thinking", thinking="", signature="sig"),
+            self.TextBlock(type="text", text='{"pass": true}'),
+        ]
+        client = self._fake_client(content)
+        task, conversation = self._task_and_conversation()
+        grade = self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
+        call = client.messages.calls[0]
+        assert "thinking" not in call
+        assert call["output_config"] == {"effort": "low"}
+        assert call["max_tokens"] == 8192
+        assert grade["pass"] is True
+
+    def test_older_model_omits_thinking_kwargs(self):
+        client = self._fake_client([self.TextBlock(type="text", text='{"pass": false}')])
+        task, conversation = self._task_and_conversation()
+        grade = self.grade_one(client, "claude-haiku-4-5-20251001", task, conversation, examples_block="")
+        call = client.messages.calls[0]
+        assert "thinking" not in call
+        assert "output_config" not in call
+        assert grade["pass"] is False
+
+    def test_response_with_only_thinking_blocks_raises(self):
+        content = [self.ThinkingBlock(type="thinking", thinking="", signature="sig")]
+        client = self._fake_client(content)
+        task, conversation = self._task_and_conversation()
+        with pytest.raises(RuntimeError, match="no TextBlock"):
+            self.grade_one(client, "claude-fable-5", task, conversation, examples_block="")
+
+
 class TestCodeGenEmptyWorkdirAutofail:
     """grade_one autofails code-gen tasks whose workdir is empty — no file =
     no deliverable, regardless of how good the conversation looked."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1069,6 +1069,19 @@ class TestGraderRequestKwargs:
         assert self.kwargs("claude-fable-5") == expected
         assert self.kwargs("claude-mythos-5") == expected
 
+    def test_pinned_dated_snapshot_of_a_five_series_model_still_matches(self):
+        assert self.kwargs("claude-opus-5-20260315") == {"max_tokens": 4096, "thinking": {"type": "disabled"}}
+        assert self.kwargs("claude-fable-5-20260315") == {
+            "max_tokens": 8192,
+            "output_config": {"effort": "low"},
+        }
+
+    def test_unrelated_legacy_model_id_is_not_misclassified(self):
+        """claude-instant-1 has the same shallow family-digit shape as
+        claude-opus-5 but is a different, older family that never had a
+        thinking concept -- it must fall through to plain max_tokens."""
+        assert self.kwargs("claude-instant-1") == {"max_tokens": 4096}
+
 
 class TestGradeOneThinkingModels:
     """grade_one: request shape and response parsing across model families."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1256,13 +1256,16 @@ class TestGradeCliMaxTokensFlag:
     """`cultivar grade --max-tokens` is wired up on the CLI, not just grade_one()."""
 
     def test_max_tokens_flag_is_registered(self):
-        from typer.testing import CliRunner
+        # Inspect the registered click command directly rather than parsing
+        # rendered --help text -- Rich wraps that output differently
+        # depending on terminal width, which made this flaky in CI.
+        import typer
 
         from evals.cli import app
 
-        result = CliRunner().invoke(app, ["grade", "--help"])
-        assert result.exit_code == 0, result.output
-        assert "--max-tokens" in result.output
+        grade_command = typer.main.get_command(app).commands["grade"]
+        option_names = {opt for param in grade_command.params for opt in param.opts}
+        assert "--max-tokens" in option_names
 
 
 class TestCodeGenEmptyWorkdirAutofail:


### PR DESCRIPTION
## Why

The grader couldn't use Claude's newer "-5" models (e.g. `claude-opus-5`, `claude-sonnet-5`) or Fable/Mythos 5 — they enable extended thinking by default, and the grader assumed the API response was always plain text, so it crashed.

## What

- Detect model family and configure requests accordingly, so 5-series models grade correctly without changing behavior for any existing model.
- Parse responses more robustly, still catching genuine misconfiguration.
- One bad grading call no longer aborts an entire batch — except auth/permission errors, which still fail fast.
- Added `--max-tokens` as a CLI option.
- Updated docs and tests.

No changes for anyone using existing models today.