### PR TITLE
Document grade's --model and --max-tokens in the skill

### DIFF
--- a/skills/cultivar/SKILL.md
+++ b/skills/cultivar/SKILL.md
@@ -31,6 +31,8 @@ when no `ANTHROPIC_API_KEY` is available) — it runs a packaged smoke task end-
   - `--grade` grade after running · `--title NAME` label the run · `--dry-run` print the
     prompt + command without calling anything · `--timeout S` per-call budget (default 90)
 - `cultivar grade <run|latest> -s <skill> [--report]` — (re)grade an existing run.
+  `--model` picks the grading model (any current Claude model works, including the "-5"
+  generation) · `--max-tokens` raises the per-reply budget if evidence/reasoning truncate.
 - `cultivar report [run]` — summary table across runners/variants.
 - `cultivar show <run|latest> -t <task> [--grader|--conversation-only|--workdir]` — inspect one run.
 


### PR DESCRIPTION
skills/cultivar/SKILL.md didn't mention --model or --max-tokens on the grade command, so it was out of sync with the recent grader fix that added support for Claude's "-5" models and exposed --max-tokens as a flag.

Bundling this with the next release (0.4.2) alongside #20.