### PR TITLE
Full docs audit against current code

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,7 +12,7 @@ cultivar automates that comparison.
 
 ## The unit of measurement: a task
 
-A **task** is a small, self-contained jobs the agent is asked to do, plus a description of what success looks like:
+A **task** is a small, self-contained job the agent is asked to do, plus a description of what success looks like:
 
 ```yaml
 - id: list-indexes
@@ -23,7 +23,7 @@ A **task** is a small, self-contained jobs the agent is asked to do, plus a desc
       FAIL if it uses the SDK directly or invents indexes.
 ```
 
-The agent runs the task. cultivar saves the conversation. An LLM grader reads the conversation against the criteria and returns `{pass, evidence, reasoning}`.
+The agent runs the task. cultivar saves the conversation. An LLM grader reads the conversation against the criteria and returns `{pass, proposed_command, evidence, reasoning, suggestions}`.
 
 That's the atom. Everything else is composition: many tasks per skill, many runs per task, many runners.
 

--- a/docs/grader.md
+++ b/docs/grader.md
@@ -10,25 +10,29 @@ LLM-based grader that scores runner conversations against natural-language crite
 
 ## Required env
 
-`ANTHROPIC_API_KEY`. Drop it in `.env` (cwd) — auto-loaded.
+`ANTHROPIC_API_KEY`. Drop it in `.env` in your cwd. It's auto-loaded.
 
 ## Model
 
-Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…` — any current Claude model works, including the "-5" generation (`claude-opus-5`, `claude-sonnet-5`, optionally pinned to a dated snapshot like `claude-opus-5-20260315`) and Fable/Mythos 5, which think by default. The grader classifies the model from its id alone and adjusts the request so the reply is still plain JSON text:
+Default: `claude-haiku-4-5-20251001`. Override with `--model claude-…`. Any current Claude model works, including the "-5" generation (`claude-opus-5`, `claude-sonnet-5`, `claude-haiku-5`, optionally pinned to a dated snapshot like `claude-opus-5-20260315`) and Fable/Mythos 5, which always think and can't turn it off. The grader classifies the model from its id alone and adjusts the request so the reply is still plain JSON text:
 
-- Older models (`claude-haiku-4-5`, `claude-sonnet-4-6`, the 4.x Opus/Sonnet line) already default to no thinking — nothing changes for them.
-- Bare or dated "-5" models (`claude-opus-5`, `claude-sonnet-5`, `claude-opus-5-20260315`, …) think by default, so the grader explicitly sends `thinking: {"type": "disabled"}`.
-- `claude-fable-5` / `claude-mythos-5` (and their dated snapshots) can't disable thinking at all — the grader omits the `thinking` param, runs at `effort: low` to keep thinking shallow, and doubles `--max-tokens` since thinking and the JSON reply share the same budget.
+- Older models (`claude-haiku-4-5`, `claude-sonnet-4-6`, the 4.x Opus/Sonnet line) already default to no thinking. Nothing changes for them.
+- Bare or dated "-5" models (`claude-opus-5`, `claude-sonnet-5`, `claude-haiku-5`, `claude-opus-5-20260315`, …) think by default, so the grader explicitly sends `thinking: {"type": "disabled"}`.
+- `claude-fable-5` / `claude-mythos-5` (and their dated snapshots) can't disable thinking at all. The grader omits the `thinking` param, runs at `effort: low` to keep thinking shallow, and doubles `--max-tokens` since thinking and the JSON reply share the same budget.
 
-Response parsing scans past leading `thinking`/`redacted_thinking` blocks for the first text block instead of assuming it's `content[0]`, but still raises loudly on any other unexpected block type (e.g. `tool_use` — this call never passes tools, so seeing one means something is misconfigured).
+Response parsing scans past leading `thinking`/`redacted_thinking` blocks for the first text block instead of assuming it's `content[0]`. It still raises loudly on any other unexpected block type, e.g. `tool_use`, since this call never passes tools and seeing one means something is misconfigured.
 
 ## Max tokens
 
-`--max-tokens` (default `4096`) caps each grader reply. Raise it if `evidence`/`reasoning` are getting truncated — check `grades.json` for a `reasoning` mentioning `_salvage_truncated_grade`'s header-only recovery — or if you're using a model whose thinking can't be disabled; those already get double whatever value you pass here.
+`--max-tokens` (default `4096`) caps each grader reply.
+
+Raise it if `evidence`/`reasoning` are getting truncated. Check `grades.json` for a `reasoning` mentioning `_salvage_truncated_grade`'s header-only recovery. Models that can't disable thinking (`claude-fable-5`, `claude-mythos-5`) already get double whatever value you pass here.
 
 ## Grader call failures
 
-If a single conversation's grading call raises (e.g. a thinking-only model exhausts `--max-tokens` before producing any text), it no longer aborts the whole run. `_grade_conversation_safely` converts the exception into a normal FAIL grade with a `cause`/`fix` suggestion naming the error, prints a warning, and the rest of the batch continues — only that one entry needs a re-grade.
+If a single conversation's grading call raises (e.g. a thinking-only model exhausts `--max-tokens` before producing any text), it no longer aborts the whole run. `_grade_conversation_safely` converts the exception into a normal FAIL grade with a `cause`/`fix` suggestion naming the error, prints a warning, and the batch continues. Only that one entry needs a re-grade.
+
+Exception: `AuthenticationError` and `PermissionDeniedError` (a bad or revoked API key) still propagate and crash the run immediately. That failure repeats identically on every remaining conversation, so surfacing it once beats grinding through the batch producing a wall of duplicate FAIL grades.
 
 ## Prompt anatomy
 
@@ -37,7 +41,7 @@ The grader prompt is assembled in this order ([`build_grader_prompt`](../evals/f
 1. **Skill reference** — full `SKILL.md` of `--skill` (auto-detected from `tasks.json` if not passed)
 2. **Criteria** — `task.ground_truth.criteria` verbatim
 3. **Expected** — `commands`, `flexible`, `outcome` (each line if present)
-4. **Reference material** — files listed in `task.ground_truth.context_refs` (cwd-relative paths), included verbatim. Capped at 100 KB combined; missing files warn + skip. Treated as ground truth for "what correct behavior looks like" — the grader can use it to judge specifics but isn't allowed to quote from it as evidence (evidence must come from the actual run). See [docs/task-yaml.md#worked-example-context_refs](task-yaml.md#worked-example-context_refs).
+4. **Reference material** — files listed in `task.ground_truth.context_refs` (cwd-relative paths), included verbatim. Capped at 100 KB combined; missing files warn + skip. Treated as ground truth for "what correct behavior looks like": the grader can use it to judge specifics but can't quote from it as evidence (evidence must come from the actual run). See [docs/task-yaml.md#worked-example-context_refs](task-yaml.md#worked-example-context_refs).
 5. **Calibration examples** — pass/fail YAMLs filtered by `task_id`
 6. **Agent conversation** — `conversation_md` truncated at 50 KB
 7. **Verification output** — stdout of `task.verify` if defined
@@ -50,9 +54,9 @@ The grader prompt is assembled in this order ([`build_grader_prompt`](../evals/f
 - **Included names:** `Dockerfile Makefile requirements.txt pyproject.toml package.json .env.example`
 - **Skipped dirs:** `__pycache__ node_modules .venv .git dist build`
 - **Skipped files:** `*.lock`
-- **Cap:** 40 KB total — files truncated or omitted past the cap, with a note appended
+- **Cap:** 40 KB total. Files truncated or omitted past the cap, with a note appended.
 
-Empty or missing workdirs contribute nothing — the section is omitted from the prompt entirely.
+Empty or missing workdirs contribute nothing. The section is omitted from the prompt entirely.
 
 ## `context_refs` is dual-use
 
@@ -73,12 +77,12 @@ reasoning: |
   why this passes (or fails) the criteria
 ```
 
-**Filtering.** Examples are filtered by `task_id` — only examples matching the active task are included. This keeps prompts small and on-topic.
+**Filtering.** Examples are filtered by `task_id`. Only examples matching the active task are included, keeping prompts small and on-topic.
 
 **Authoring tips:**
-- Pin examples to *real* runs, not hypotheticals. The closer to actual runner output, the better the calibration.
+- Pin examples to *real* runs. Skip hypotheticals. The closer to actual runner output, the better the calibration.
 - Write `reasoning` from the grader's perspective: "passes because…" / "fails because…", citing the criteria.
-- Add a fail example *before* tightening criteria — it teaches the grader the failure mode without you having to over-specify.
+- Add a fail example *before* tightening criteria. It teaches the grader the failure mode without over-specifying.
 
 **Promoting a run to an example.** Copy the relevant conversation or workdir content into an example YAML by hand for now.
 
@@ -101,7 +105,7 @@ reasoning: |
 
 ## Re-grading
 
-`cultivar grade latest --report` re-grades without re-running the agents. Use this loop when iterating on `criteria` or adding calibration examples — it's cheap (one Haiku call per task) and fast.
+`cultivar grade latest --report` re-grades without re-running the agents. Use this loop when iterating on `criteria` or adding calibration examples. It's cheap (one Haiku call per task) and fast.
 
 ## Sources
 

--- a/docs/runners/copilot.md
+++ b/docs/runners/copilot.md
@@ -31,7 +31,7 @@ copilot --autopilot --yolo \
 
 | | with-skill | without-skill | with-docs |
 |---|---|---|---|
-| Prompt | `Use the /<skill> skill. <intent>` | `<intent>` | `<context_refs>\n---\n<intent>` |
+| Prompt | `Use the /<skill> skill. <intent>` | `<intent>` | `<docs_context><intent>` |
 | `--no-custom-instructions` | no | yes | yes |
 | `--excluded-tools skill` | no | yes | yes |
 

--- a/docs/runners/gemini.md
+++ b/docs/runners/gemini.md
@@ -31,7 +31,7 @@ If the orchestrator passes a `cwd` (the per-task tempdir), every variant uses it
 
 ## Quirks
 
-- `gemini skills link` is interactive — we pipe `"Y\n"` and a 30s timeout. Failures are swallowed (skill may already be linked from a previous run).
+- `gemini skills link` is interactive. We pipe `"Y\n"` with a 30s timeout. A timeout or non-zero exit is swallowed (skill may already be linked from a previous run). If the `gemini` CLI itself is missing, the run aborts immediately with a `gemini_cli_not_found` error.
 - No turn limit flag, so `--max-turns` translates to a subprocess timeout, not a hard cap on agent turns.
 - Event schema differs from Claude: looks for `type=message`, `tool_use`, `tool_result`, `result`, plus stats under `result.stats` with field names like `tool_calls`, `input_tokens`, `output_tokens`, `cached`.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -23,7 +23,7 @@ Per (task, variant, repeat), one sandbox:
 | **setup** | `task.setup` shell command, if defined | `*.setup.log` (failure aborts the run) |
 | **eval** | `entry.py` → real runner class → JSON result on stdout | `sandbox_timing.eval_s` |
 | **verify** | `task.verify` shell command, if defined; stdout passed to grader | `*.verify.log`; stdout in `result.verify_output` |
-| **workdir capture** | `find /workspace/app -type f` + per-file `sb.open(path, "rb").read()` → local `write_bytes` | `*.workdir/` |
+| **workdir capture** | `find /workspace/app -type f` + per-file `sb.filesystem.read_bytes(path)` → local `write_bytes` | `*.workdir/` |
 | **teardown** | `task.teardown` shell command, if defined | `*.teardown.log` |
 | **terminate** | `sb.terminate()` (in `finally`) | always runs |
 
@@ -44,6 +44,7 @@ Set with `--timeout <seconds>` (default `90`). That value is the **agent CLI bud
 | Modal app name | `cultivar` by default; override with `CULTIVAR_MODAL_APP` env var |
 | Parallelism | `--parallel N` (default 5) |
 | Repeats | `--repeat N` |
+| Model | `--model <name>` (Claude runner only; Copilot/Gemini accept and ignore it) |
 | Per-call timeout | `--timeout <seconds>` (default 90; sandbox gets +60s buffer) |
 
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -21,7 +21,7 @@ That's it. No version, no metadata. The list under `tasks:` is what gets loaded.
 |---|---|---|---|
 | `id` | yes | string | Unique within the file. Used by `--task <id>` filter and as the result base name (`<id>__<variant>.json`). |
 | `intent` | yes | string | The user prompt sent to the agent. With-skill variant prepends `Use the /<skill> skill. ` |
-| `category` | no | string | Tag for `--category <name>` filtering. Free-form. |
+| `category` | no | string | Tag for `--category <name>` filtering. Free-form, with one special value: `code-gen`. If set, the grader autofails the task when the captured workdir is empty, without calling the API. |
 | `setup` | no | string (shell) | Runs before the agent. Locally: in your shell. Remote: inside the sandbox. Non-zero exit aborts the run. |
 | `teardown` | no | string (shell) | Runs after the agent (and after `verify`). Same exec context as `setup`. |
 | `verify` | no | string (shell) | Runs after the agent. Stdout is captured into `result.verify_output` and **fed to the grader** under "Verification Output". Use this to check post-run state (e.g. `pc index stats my-test-index`). |
@@ -33,7 +33,7 @@ That's it. No version, no metadata. The list under `tasks:` is what gets loaded.
 
 | Field | Required | Type | What it does |
 |---|---|---|---|
-| `criteria` | yes (within ground_truth) | string (multi-line) | Free-form PASS/FAIL description. The grader's primary input. Be specific. |
+| `criteria` | no (but grading is meaningless without it) | string (multi-line) | Free-form PASS/FAIL description. The grader's primary input. If missing, the grader sees "(no specific criteria provided)". Be specific. |
 | `commands` | no | list of strings | Expected commands the agent should run. Surfaced to the grader as a hint. |
 | `flexible` | no | list of strings | Notes about acceptable variation (e.g. `"single or double quotes ok"`, `"file extension can be .py or .pyw"`). |
 | `outcome` | no | string | Short description of expected end state. Surfaced to the grader. |
@@ -88,7 +88,7 @@ tasks:
     category: code-gen
 ```
 
-The agent runs in a per-task tempdir; anything it writes is captured to `results/<run>/<runner>/<id>__<variant>.workdir/` and fed to the grader.
+The agent runs in a per-task tempdir; anything it writes is captured to `results/<run>/<runner>/<id>__<variant>.workdir/` and fed to the grader. With `category: code-gen`, an empty workdir autofails the task before the grader API is even called.
 
 ## Where the YAML lives
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -2,7 +2,7 @@
 
 This is the Python package that backs the `cultivar` CLI. End-user docs live in [README.md](../README.md) (top-level) and the [docs/](../docs) tree. This file is a code-oriented orientation for anyone reading or editing the framework itself.
 
-If you just want to *use* cultivar, you're in the wrong place — start with [the top-level README](../README.md) and [docs/concepts.md](../docs/concepts.md).
+If you just want to *use* cultivar, you're in the wrong place. Start with [the top-level README](../README.md) and [docs/concepts.md](../docs/concepts.md).
 
 ## What's in here
 
@@ -28,7 +28,7 @@ evals/
   _resources/smoke/      # Packaged hello-world task + skill, shipped in the wheel
 ```
 
-`cli.py::app` is the Typer root. Subcommands are mounted via `app.command("init")(init_main)` etc. — each subcommand's `main` lives in its own module.
+`cli.py::app` is the Typer root. Subcommands are mounted via `app.command("init")(init_main)` etc. Each subcommand's `main` lives in its own module.
 
 ## The Runner contract
 
@@ -43,15 +43,19 @@ class Runner(ABC):
 
     @abstractmethod
     def build_command(
-        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = ""
+        self, intent: str, variant: str, max_turns: int = 10, docs_context: str = "",
+        extra_tools: list[str] | None = None, model: str | None = None,
     ) -> tuple[list[str], str]: ...   # (argv, full_prompt) — used by --dry-run
 
     @abstractmethod
     def run(
         self, intent: str, variant: str, max_turns: int = 10,
         cwd: str | None = None, docs_context: str = "", timeout: int = 90,
+        extra_tools: list[str] | None = None, model: str | None = None,
     ) -> dict: ...
 ```
+
+`extra_tools` is the task YAML's `extra_tools:` opt-in, unioned into the variant's tool allow-list. `model` is `cultivar run --model <id>`, an orchestration-level override of the agent CLI's model. Runners with no matching mechanism (Copilot, Gemini) accept and ignore both.
 
 `run()` returns a dict whose only required key is `conversation_md` (the readable trace). Optional but recommended: `raw_events`, `session_id`, `duration_ms`, `total_cost_usd`, `num_turns`, `usage`, `stderr`, `error`.
 
@@ -61,55 +65,60 @@ To add a new runner, subclass `Runner`, register in `run.py::RUNNER_CLASSES`, an
 
 ## Local vs remote: two orchestrators, one contract
 
-Both `run_local` and `run_remote` (in `run.py`) iterate `(task × variant × repeat)` and call the same runner classes — the difference is where the subprocess lives.
+Both `run_local` and `run_remote` (in `run.py`) iterate `(task × variant × repeat)` and call the same runner classes. The difference is where the subprocess lives.
 
 **Local (`run_local`):**
 - Each iteration runs in a fresh `tempfile.TemporaryDirectory()` as the agent's cwd.
 - For `with-skill`, the skill is copied into `<tmpdir>/.claude/skills/<name>/` before the runner is called, so Claude Code / Copilot can discover it via walk-up.
-- After the runner returns, non-noise contents of the tmpdir get copied to `<runner>/<base>.workdir/`.
+- After the runner returns, non-noise contents of the tmpdir get copied to `<runner>/<base>.workdir/`. `.claude` is excluded: with-skill mounts the skill there and it isn't agent output. Without the exclusion the code-gen empty-workdir autofail (see below) wouldn't fire.
 
 **Remote (`run_remote`):**
 - Each iteration submits a `run_one_remote()` call to a `ThreadPoolExecutor` (max workers = `--parallel`, default 5).
 - `modal_runner.py` creates a fresh `modal.Sandbox` per iteration with the image, the secret named by `CULTIVAR_MODAL_SECRET` (default: `eval-sandbox-secrets`), and a `+60s` buffer on top of the agent's `--timeout`.
 - For `with-skill`, the skill is mounted into the image at `/workspace/.claude/skills/<name>/`; the agent's cwd is `/workspace/app/`.
-- `entry.py` runs inside the sandbox, imports the same `Runner` class, calls `.run()`, prints JSON to stdout. The orchestrator parses that and pulls workdir files out via per-file `sb.open(..., "rb").read()`.
+- `entry.py` runs inside the sandbox, imports the same `Runner` class, calls `.run()`, prints JSON to stdout. The orchestrator parses that and pulls workdir files out via per-file `sb.filesystem.read_bytes(path)`.
 
-The whole point of `entry.py` is to avoid a reimplementation: identical runner output local and remote.
+`entry.py` keeps runner output identical between local and remote runs, without a second implementation of the runner.
 
 See [docs/sandbox.md](../docs/sandbox.md) for the full lifecycle, image contents, and DIY workspace setup.
 
 ## The grader
 
-`framework/grader.py` runs **locally only** (never inside the sandbox — keeps the Anthropic key on the user's machine). For each conversation in a run dir, it:
+`framework/grader.py` runs **locally only**. It never runs inside the sandbox, so the Anthropic key stays on the user's machine. For each conversation in a run dir, it:
 
 1. Builds a prompt from: skill SKILL.md + task criteria + `context_refs` reference material + calibration examples + the conversation + verify output + any workdir files.
 2. Sends to Claude Haiku (or `--model`).
 3. Parses the JSON response into a grade `{pass, evidence, reasoning, suggestions, ...}`.
 
-Two pre-API short-circuits to avoid hallucinated grades:
+Two pre-API short-circuits avoid hallucinated grades:
 - Empty/no-signal conversation → autofail before the call.
 - `category: code-gen` with an empty workdir → autofail before the call.
 
-If the model truncates its JSON mid-evidence, `_salvage_truncated_grade()` regex-extracts the verdict so a real PASS doesn't become a fake FAIL. Default reply budget is `--max-tokens 4096` (doubled automatically for models that can't disable thinking, e.g. `claude-fable-5`); raise it if truncation recurs.
+Thinking-by-default models:
+- Claude's "-5" generation (`claude-opus-5`, `claude-sonnet-5`, `claude-haiku-5`, including pinned `-YYYYMMDD` snapshots) thinks by default. The grader sends `thinking: {"type": "disabled"}` to turn it off.
+- Fable 5 / Mythos 5 (also including pinned `-YYYYMMDD` snapshots) can't disable thinking at all. The grader omits the `thinking` param, sets a low effort, and doubles `--max-tokens` since thinking and the reply share the same budget.
+- Older models (haiku-4-5, sonnet-4-6, the 4.x Opus/Sonnet line) already default to no thinking and need no special handling.
 
-If a single grading call raises, `_grade_conversation_safely()` turns it into a FAIL grade instead of aborting the rest of the run.
+If the model truncates its JSON mid-evidence, `_salvage_truncated_grade()` regex-extracts the verdict so a real PASS doesn't become a fake FAIL. Default reply budget is `--max-tokens 4096`; raise it if truncation recurs.
+
+If a single grading call raises, `_grade_conversation_safely()` records a FAIL grade for that conversation instead of aborting the rest of the run. Auth/permission errors are the exception: those crash the run immediately, since a bad or revoked key fails the same way on every remaining conversation.
 
 Full prompt anatomy + calibration mechanics: [docs/grader.md](../docs/grader.md).
 
 ## Variants
 
-Three of them: `with-skill`, `without-skill`, `with-docs`. The third auto-activates when a task declares `ground_truth.context_refs: [...]`; otherwise it's skipped. The same `context_refs` files are used in *two* places — the grader prompt (as authoritative reference) and the with-docs runner prompt (prepended to the intent). See [docs/concepts.md#the-controls-with-skill-without-skill-with-docs](../docs/concepts.md#the-controls-with-skill-without-skill-with-docs) and [docs/task-yaml.md#variants](../docs/task-yaml.md#variants).
+Three of them: `with-skill`, `without-skill`, `with-docs`. The third auto-activates when a task declares `ground_truth.context_refs: [...]`; otherwise it's skipped. The same `context_refs` files are used in two places: the grader prompt (as authoritative reference) and the with-docs runner prompt (prepended to the intent). See [docs/concepts.md#the-controls-with-skill-without-skill-with-docs](../docs/concepts.md#the-controls-with-skill-without-skill-with-docs) and [docs/task-yaml.md#variants](../docs/task-yaml.md#variants).
 
 ## Path resolution
 
-User-data paths (`tasks/`, `examples/`, `results/`, `.claude/skills/`) are **cwd-relative**, not package-relative. Defined as module-level constants in `run.py` and `framework/grader.py` so `cultivar` installed globally resolves them from wherever it's invoked. Don't reintroduce `Path(__file__).parent`-based defaults for user data — this design is what makes the tool work from a skills repo without ever cloning this one.
+User-data paths (`tasks/`, `examples/`, `results/`, `.claude/skills/`) resolve relative to the current working directory, regardless of where the package is installed. `tasks/` and `results/` are module-level constants in `run.py`, `examples/` in `framework/grader.py`. The skills root comes from `resolve_skills_base()` in `framework/reporting.py`, which honors `--skills-dir` and `CULTIVAR_SKILLS_DIR`. Don't reintroduce `Path(__file__).parent`-based defaults for user data. This design lets a globally installed `cultivar` run from a skills repo without ever cloning this one.
 
 ## Test layout
 
-`tests/test_core.py` covers loaders, env validation, save_result, grader prompt construction + autofail short-circuits, calibration filtering, workdir filtering, packaged smoke resources, and orchestrator call-surface guards (AST-based check that `hello.py`'s calls to `run_local`/`run_remote` still match their signatures — the bug class that hit us once).
+`tests/test_core.py` covers loaders, env validation, save_result, grader prompt construction + autofail short-circuits, calibration filtering, workdir filtering, packaged smoke resources, and orchestrator call-surface guards. The last is an AST-based check that `hello.py`'s calls to `run_local`/`run_remote` still match their signatures, catching the bug class that hit us once.
 
 ```bash
-uv run pytest -q       # ~0.4s
+uv run pytest -q       # ~0.6s
 uv run ruff check .    # lint
 uv run ty check        # types
 ```

--- a/skills/cultivar/SKILL.md
+++ b/skills/cultivar/SKILL.md
@@ -31,6 +31,8 @@ when no `ANTHROPIC_API_KEY` is available) — it runs a packaged smoke task end-
   - `--grade` grade after running · `--title NAME` label the run · `--dry-run` print the
     prompt + command without calling anything · `--timeout S` per-call budget (default 90)
 - `cultivar grade <run|latest> -s <skill> [--report]` — (re)grade an existing run.
+  `--model` picks the grading model (any current Claude model works, including the "-5"
+  generation) · `--max-tokens` raises the per-reply budget if evidence/reasoning truncate.
 - `cultivar report [run]` — summary table across runners/variants.
 - `cultivar show <run|latest> -t <task> [--grader|--conversation-only|--workdir]` — inspect one run.
 

--- a/skills/cultivar/SKILL.md
+++ b/skills/cultivar/SKILL.md
@@ -30,9 +30,11 @@ when no `ANTHROPIC_API_KEY` is available) — it runs a packaged smoke task end-
   - `--remote` run in isolated Modal sandboxes · `-n N` repeat · `-p N` parallelism
   - `--grade` grade after running · `--title NAME` label the run · `--dry-run` print the
     prompt + command without calling anything · `--timeout S` per-call budget (default 90)
-- `cultivar grade <run|latest> -s <skill> [--report]` — (re)grade an existing run.
-  `--model` picks the grading model (any current Claude model works, including the "-5"
-  generation) · `--max-tokens` raises the per-reply budget if evidence/reasoning truncate.
+- `cultivar grade <run|latest> [--skill <skill>] [--no-report]` — (re)grade an existing run.
+  Skill auto-detects from the run's `tasks.json`. `--model` picks the grading model; Claude
+  4.x, the "-5" generation (opus/sonnet/haiku, bare or pinned to a dated snapshot), and
+  Fable/Mythos 5 all work · `--max-tokens` raises the per-reply budget (default 4096) if
+  evidence/reasoning truncate.
 - `cultivar report [run]` — summary table across runners/variants.
 - `cultivar show <run|latest> -t <task> [--grader|--conversation-only|--workdir]` — inspect one run.
 
@@ -100,5 +102,7 @@ grader's reasoning + suggestions on a failure.
 
 - Grading needs `ANTHROPIC_API_KEY` (loaded from a `.env` in the cwd). `hello --no-grade`
   and `run --dry-run` need no key.
+- A grader call that fails is recorded as a FAIL for that conversation and the run
+  continues. Auth and permission errors abort the whole grading run immediately.
 - `tasks/`, `examples/`, and `results/` are cwd-relative and user-owned.
-- One run is a sample, not a signal — use `-n 3` (or more) for anything you'll act on.
+- One run is a sample. Use `-n 3` (or more) for anything you'll act on.


### PR DESCRIPTION
Every docs page (docs/, evals/README.md, skills/cultivar/SKILL.md, README.md, CONTRIBUTING.md) checked against the actual source it describes.

Real fixes:
- skills/cultivar/SKILL.md: `cultivar grade` doc had wrong flags (no `-s`; `--no-report` not `--report`)
- docs/runners/copilot.md: with-docs prompt shape was wrong
- docs/runners/gemini.md: overclaimed failure handling
- docs/sandbox.md + evals/README.md: stale workdir-capture method
- docs/task-yaml.md: category: code-gen and criteria required-ness under-documented
- docs/concepts.md: stale grader return schema, a typo

New-feature docs added (grader's "-5" model support, --max-tokens, fail-fast-on-auth-error): docs/grader.md, evals/README.md, skills/cultivar/SKILL.md.

README.md, CONTRIBUTING.md, docs/runners/claude.md needed no changes.

Bundling with #21 for the 0.4.2 release.